### PR TITLE
Fix julian_millennias return type

### DIFF
--- a/src/calculus/vsop87/vsop87_impl.rs
+++ b/src/calculus/vsop87/vsop87_impl.rs
@@ -57,7 +57,7 @@ pub fn compute_vsop87(
 ) -> (f64, f64, f64) {
 
     let jd_tdb = JulianDay::tt_to_tdb(jd);
-    let t = jd_tdb.julian_millennias().value();
+    let t = jd_tdb.julian_millennias();
 
     let (x, yz) = join(
         || compute_coord_value(x_expansions, t),

--- a/src/units/time/julian_day.rs
+++ b/src/units/time/julian_day.rs
@@ -23,8 +23,8 @@ impl JulianDay {
     }
 
     #[inline]
-    pub fn julian_millennias(&self) -> Self {
-        Self((self.0 - Self::_J2000_) / 365_250.0)
+    pub fn julian_millennias(&self) -> f64 {
+        (self.0 - Self::_J2000_).value() / 365_250.0
     }
 
     #[inline]


### PR DESCRIPTION
## Summary
- adjust `julian_millennias` to directly return `f64`
- update VSOP87 calculations to use the new return type

## Testing
- `cargo test --quiet --offline` *(fails: no matching package named `approx` found)*
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io`)*

------
https://chatgpt.com/codex/tasks/task_e_684f473c7db08333a591224909ec8efd