### PR TITLE
Add tests for units, planets, vectors, and Julian dates

### DIFF
--- a/src/astro/julian_date.rs
+++ b/src/astro/julian_date.rs
@@ -160,4 +160,21 @@ mod tests {
         let jd = JulianDate::from_utc(datetime);
         assert_eq!(jd.value(), 2451545.0);
     }
+
+    #[test]
+    fn test_julian_conversions() {
+        let jd = JulianDate::J2000 + Days::new(365_250.0);
+        assert!((jd.julian_millennias() - 1.0).abs() < 1e-12);
+        assert!((jd.julian_centuries().value() - 10.0).abs() < 1e-12);
+        assert!((jd.julian_years().value() - 1000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_tt_to_tdb_and_min() {
+        let jd_tdb = JulianDate::tt_to_tdb(JulianDate::J2000);
+        assert!((jd_tdb - JulianDate::J2000).value().abs() < 1e-6);
+
+        let later = JulianDate::J2000 + Days::new(1.0);
+        assert_eq!(JulianDate::J2000.min(later), JulianDate::J2000);
+    }
 }

--- a/tests/test_cartesian.rs
+++ b/tests/test_cartesian.rs
@@ -1,0 +1,26 @@
+use siderust::coordinates::cartesian::Vector;
+use siderust::coordinates::centers::Heliocentric;
+use siderust::coordinates::frames::Ecliptic;
+use siderust::units::Au;
+
+type VecAu = Vector<Heliocentric, Ecliptic, Au>;
+
+#[test]
+fn vector_basic_operations() {
+    let v1 = VecAu::new(1.0, 0.0, 0.0);
+    let v2 = VecAu::new(0.0, 1.0, 0.0);
+
+    let sum = v1 + v2;
+    assert_eq!(sum.x().value(), 1.0);
+    assert_eq!(sum.y().value(), 1.0);
+
+    let diff = v1 - v2;
+    assert_eq!(diff.x().value(), 1.0);
+    assert_eq!(diff.y().value(), -1.0);
+
+    let dist = v1.distance();
+    assert!((dist.value() - 1.0).abs() < 1e-12);
+
+    let between = v1.distance_to(&v2);
+    assert!((between.value() - 2.0_f64.sqrt()).abs() < 1e-12);
+}

--- a/tests/test_planets.rs
+++ b/tests/test_planets.rs
@@ -1,0 +1,45 @@
+use siderust::bodies::planets::{Planet, PlanetBuilderError, OrbitExt};
+use siderust::units::{Kilograms, Kilometers, AstronomicalUnits, Degrees};
+use siderust::astro::{orbit::Orbit, JulianDate};
+
+#[test]
+fn planet_builder_errors() {
+    let builder = Planet::builder().radius(Kilometers::new(1.0)).orbit(
+        Orbit::new(
+            AstronomicalUnits::new(1.0),
+            0.0,
+            Degrees::new(0.0),
+            Degrees::new(0.0),
+            Degrees::new(0.0),
+            Degrees::new(0.0),
+            JulianDate::J2000,
+        )
+    );
+    let err = builder.clone().try_build().unwrap_err();
+    assert!(matches!(err, PlanetBuilderError::MissingMass));
+
+    let err = Planet::builder().mass(Kilograms::new(1.0)).try_build().unwrap_err();
+    assert!(matches!(err, PlanetBuilderError::MissingRadius));
+}
+
+#[test]
+fn orbit_period_computation() {
+    let orbit = Orbit::new(
+        AstronomicalUnits::new(1.0),
+        0.0,
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        JulianDate::J2000,
+    );
+    let planet = Planet::builder()
+        .mass(Kilograms::new(1.0))
+        .radius(Kilometers::new(1.0))
+        .orbit(orbit.clone())
+        .build();
+
+    let p = planet.orbit.period().value();
+    let expected = 2.0 * std::f64::consts::PI / 0.986 * 1.0_f64.powf(1.5) * 86400.0;
+    assert!((p - expected).abs() < 1e-6);
+}

--- a/tests/test_units.rs
+++ b/tests/test_units.rs
@@ -1,0 +1,19 @@
+use siderust::units::angular::{HourAngles, Degrees};
+
+#[test]
+fn hour_angles_from_hms() {
+    let ha = HourAngles::from_hms(5, 30, 0.0);
+    assert!((ha.value() - 5.5).abs() < 1e-12);
+
+    let neg = HourAngles::from_hms(-5, 15, 30.0);
+    assert!((neg.value() + 5.258333333333333).abs() < 1e-12);
+}
+
+#[test]
+fn degrees_from_dms() {
+    let deg = Degrees::from_dms(-33, 52, 0.0);
+    assert!((deg.value() + 33.86666666666667).abs() < 1e-12);
+
+    let with_sign = Degrees::from_dms_sign(-1, 33, 52, 0.0);
+    assert!((with_sign.value() + 33.86666666666667).abs() < 1e-12);
+}


### PR DESCRIPTION
## Summary
- add tests for angle builders and conversions
- test planet builder error cases and period calculations
- cover cartesian vector operations and Julian date helpers

## Testing
- `cargo test` *(fails: VSOP87 codegen failed: Fetching VSOP87 directory listing)*

------
https://chatgpt.com/codex/tasks/task_e_6898627441488333b9ab7bce3df12752