### PR TITLE
Add bodies tests and offline build stubs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,12 +4,57 @@ mod vsop87_build;
 #[path = "scripts/elp2000/mod.rs"]
 mod elp2000_build;
 
-use std::{env, path::PathBuf};
+use std::{env, fs, path::{PathBuf, Path}};
+
+fn write_stub_files(out_dir: &Path) {
+    // Minimal VSOP87 stub with all required constants but empty data
+    fn stub_vsop() -> String {
+        use std::fmt::Write;
+        let mut s = String::new();
+        writeln!(s, "use crate::calculus::vsop87::vsop87_impl::Vsop87;").unwrap();
+        let bodies = ["MERCURY","VENUS","EARTH","MARS","JUPITER","SATURN","URANUS","NEPTUNE","EMB","SUN"];
+        for body in bodies.iter() {
+            for coord in ["X","Y","Z"].iter() {
+                for power in 0..=5 {
+                    writeln!(s, "pub static {body}_{coord}{power}: [Vsop87; 0] = [];").unwrap();
+                }
+            }
+        }
+        s
+    }
+
+    // Minimal ELP2000 stub with empty series arrays
+    fn stub_elp() -> String {
+        use std::fmt::Write;
+        let mut s = String::new();
+        writeln!(s, "use crate::calculus::elp2000::elp_structs::{{MainProblem, EarthPert, PlanetPert}};").unwrap();
+        for idx in 1..=36 {
+            let typ = if (1..=3).contains(&idx) {
+                "MainProblem"
+            } else if (10..=21).contains(&idx) {
+                "PlanetPert"
+            } else {
+                "EarthPert"
+            };
+            writeln!(s, "pub static ELP{idx}: &[{typ}] = &[];").unwrap();
+        }
+        s
+    }
+
+    fs::write(out_dir.join("vsop87a.rs"), stub_vsop()).expect("write vsop87a stub");
+    fs::write(out_dir.join("vsop87e.rs"), stub_vsop()).expect("write vsop87e stub");
+    fs::write(out_dir.join("elp_data.rs"), stub_elp()).expect("write elp stub");
+}
 
 fn main() {
     let out_dir = PathBuf::from(
         env::var("OUT_DIR").expect("OUT_DIR not set by Cargo"),
     );
+
+    if env::var("SIDERUST_STUBS").is_ok() {
+        write_stub_files(&out_dir);
+        return;
+    }
 
     // VSOP87
     let data_dir = out_dir.join("vsop87_dataset");

--- a/tests/test_bodies.rs
+++ b/tests/test_bodies.rs
@@ -1,0 +1,67 @@
+use siderust::astro::orbit::Orbit;
+use siderust::astro::JulianDate;
+use siderust::units::{AstronomicalUnits, Degrees, Kilometers, Kilograms};
+use siderust::bodies::asteroid::{Asteroid, AsteroidClass};
+use siderust::bodies::comet::{Comet, OrbitFrame, HALLEY};
+use siderust::bodies::planets::{Planet, PlanetBuilderError, OrbitExt};
+
+#[test]
+fn asteroid_builder_defaults() {
+    let orbit = Orbit::new(
+        AstronomicalUnits::new(1.0),
+        0.1,
+        Degrees::new(1.0),
+        Degrees::new(2.0),
+        Degrees::new(3.0),
+        Degrees::new(4.0),
+        JulianDate::J2000,
+    );
+    let asteroid = Asteroid::builder()
+        .name("Test")
+        .designation("T1")
+        .orbit(orbit)
+        .build();
+    assert_eq!(asteroid.composition, "Unknown");
+    assert_eq!(asteroid.class, AsteroidClass::MainBelt);
+}
+
+#[test]
+fn comet_builder_defaults_and_period() {
+    let orbit = HALLEY.orbit;
+    let comet = Comet::builder()
+        .name("X/1 Test")
+        .tail_length(Kilometers::new(1.0e6))
+        .orbit(orbit)
+        .build();
+    assert_eq!(comet.reference, OrbitFrame::Heliocentric);
+    let period = HALLEY.period_years();
+    assert!((period - 75.0).abs() < 5.0);
+}
+
+#[test]
+fn planet_builder_errors_and_period() {
+    let orbit = Orbit::new(
+        AstronomicalUnits::new(1.0),
+        0.0,
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        JulianDate::J2000,
+    );
+    let err = Planet::builder()
+        .mass(Kilograms::new(1.0))
+        .orbit(orbit)
+        .try_build()
+        .unwrap_err();
+    assert!(matches!(err, PlanetBuilderError::MissingRadius));
+
+    let planet = Planet::builder()
+        .mass(Kilograms::new(1.0))
+        .radius(Kilometers::new(1.0))
+        .orbit(orbit)
+        .build();
+    let period_days = planet.orbit.period().value() / 86_400.0;
+    let expected_days = 2.0 * std::f64::consts::PI / 0.986 * (1.0f64).powf(1.5);
+    assert!((period_days - expected_days).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- allow offline builds via `SIDERUST_STUBS` environment variable
- add integration tests for asteroid, comet, and planet builders

## Testing
- `SIDERUST_STUBS=1 cargo test --test test_bodies`

------
https://chatgpt.com/codex/tasks/task_e_6898627441488333b9ab7bce3df12752