### PR TITLE
Refine module documentation

### DIFF
--- a/src/astro/mod.rs
+++ b/src/astro/mod.rs
@@ -1,20 +1,19 @@
-//! # Astro Module
+//! Astronomical time scales and positional corrections.
 //!
-//! This module provides astronomical calculations and utilities, including:
-//! - Sidereal time computations for tracking celestial objects.
-//! - Nutation corrections for Earth's rotational axis wobble.
-//! - Dynamical time calculations for precise timekeeping in astronomy.
-//! - Annual Aberration to consider relativistic correction due to the Earth's orbital motion
-//! - Astronomical Dates such as JulianDate and Modified Julian Date.
+//! The `astro` module gathers low‑level routines that model phenomena affecting
+//! precise astronomical observations.  It covers time representations, Earth
+//! orientation, relativistic effects and basic orbital tools.  Each component is
+//! allocation‑free and designed for cross‑validation against published models.
 //!
-//! ## Submodules
-//! - [`sidereal`]: Handles sidereal time calculations, including GST and LST.
-//! - [`nutation`]: Computes nutation components (Δψ, Δε) and applies corrections.
-//! - [`dynamical_time`]: Converts between Universal Time (UT) and Terrestrial Time (TT).
-//! - [`aberration`]: Applies annual aberration corrections to celestial coordinates.
-//! - [`orbit`]: Provides utilities for orbital mechanics and celestial object tracking.
-//! - [`julian_date`]: Implements Julian Date calculations.
-//! - [`modified_julian_date`]: Implements Modified Julian Date calculations.
+//! ## Components
+//! - [`julian_date`] and [`modified_julian_date`] time tags commonly used in
+//!   dynamical astronomy.
+//! - [`dynamical_time`] conversions between universal and terrestrial time.
+//! - [`nutation`] and [`precession`] describing Earth orientation.
+//! - [`aberration`] annual aberration corrections.
+//! - [`sidereal`] computation of Greenwich and local sidereal time.
+//! - [`orbit`] helpers for classical orbital elements.
+//! - [`proper_motion`] linear motion of stars.
 
 pub mod aberration;
 pub mod proper_motion;

--- a/src/bodies/mod.rs
+++ b/src/bodies/mod.rs
@@ -1,61 +1,36 @@
-//! # Astronomical Bodies
+//! Data and helper types for natural and artificial bodies.
 //!
-//! A **central hub** that exposes type definitions, ephemerides, and physical
-//! parameters for the natural objects that populate our Universe.  Whether you
-//! need the sidereal period of *Mars*, the absolute magnitude of *Halley’s Comet*,
-//! or the radius of *Betelgeuse*, this module places those numbers at your
-//! fingertips while preserving **strong type‑safety** through siderust unit system.
+//! The `bodies` module exposes ephemerides and physical parameters for a range
+//! of solar‑system objects and stars.  Frequently used constants such as
+//! `SUN`, `MOON` or `JUPITER` are available as `const` values for use in
+//! compile‑time contexts, while more extensive datasets live in dedicated
+//! submodules and are re‑exported here for convenience.  All quantities retain
+//! their units through the [`units`](../units/index.html) system to avoid
+//! accidental mixing.
 //!
-//! The module is intentionally lightweight: all frequently accessed constants
-//! (e.g. `SUN`, `MOON`, `JUPITER`) are available at **compile‑time** so they can
-//! be used inside `const fn` and embedded targets. More detailed or mutable
-//! datasets—such as time‑dependent orbital elements—live in their dedicated
-//! sub‑modules but are re‑exported here for convenience.
+//! ## Submodules
+//! - [`solar_system`]: canonical data for planets, major moons and Lagrange points.
+//! - [`planets`]: [`Planet`] type and builders from Keplerian elements.
+//! - [`satelite`]: natural satellites and artificial spacecraft with optional SGP4 propagation.
+//! - [`comet`]: preset and user‑defined comet orbits.
+//! - [`asteroid`]: minor‑planet definitions.
+//! - [`stars`]: [`Star`] type and stellar parameters.
+//! - [`catalog`]: curated catalog of bright stars.
 //!
-//! ## Sub‑module overview
-//! | Path | Purpose | Highlights |
-//! |------|---------|------------|
-//! | [`solar_system`] | Canonical Sun, planets, major moons, dwarf planets, and Lagrange points | `SOLAR_SYSTEM` aggregate constant |
-//! | [`planets`] | Generic [`Planet`] type plus planet builder utilities | Unit‑safe Keplerian elements |
-//! | [`satelite`] | Natural moons and artificial satellites (TLE support) | `MOON` constant, SGP4 propagator |
-//! | [`comet`] | Barycentric and heliocentric comet orbits | Halley, Encke, Hale‑Bopp presets |
-//! | [`asteroid`] | Minor planets and near‑Earth objects | Ceres, Bennu, Apophis |
-//! | [`stars`] | Generic [`Star`] type and stellar parameter helpers |  mass, luminosity ... |
-//! | [`catalog`] | Hand‑picked bright‑star catalog | [`catalog::VEGA`], [`catalog::SIRIUS`] |
-//!
-//! ## Quick start
+//! ## Example
 //! ```rust
-//! use siderust::bodies::{Star, Planet, EARTH};
+//! use siderust::bodies::{catalog::ALTAIR, EARTH};
 //!
-//! // Look up Earth in the pre‑baked Solar System constant
-//! let earth: &Planet = &EARTH;
-//! println!("Earth {:?}", earth);
+//! // Access Earth from the solar‑system constants
+//! println!("Earth radius: {}", EARTH.radius);
 //!
-//! // Grab a famous bright star from the catalog
-//! use siderust::bodies::catalog::ALTAIR;
+//! // Retrieve a bright star from the catalog
 //! println!("{} is {} away", ALTAIR.name, ALTAIR.distance);
 //! ```
 //!
-//! ## Design philosophy
-//! * **Type safety first** — every physical quantity carries its unit.
-//! * **Zero runtime cost** for built‑in constants.
-//! * **Ergonomic**: most commonly used types (`Planet`, `Star`, `Comet`, …) are
-//!   re‑exported at the crate root to minimise path noise.
-//! * **Extensibility**: each sub‑module can be expanded independently as new
-//!   data become available.
-//!
 //! ## Re‑exports
-//! The following items are publicly re‑exported so you can write, for example,
-//! `use astro::bodies::Star;` instead of `use astro::bodies::stars::Star;`:
-//!
-//! * [`Comet`]
-//! * [`Asteroid`]
-//! * [`Satellite`]
-//! * [`Planet`]
-//! * [`Star`]
-//! * Everything inside [`solar_system`]
-//!
-//! ---
+//! [`Comet`], [`Asteroid`], [`Satellite`], [`Planet`], [`Star`] and all items
+//! from [`solar_system`].
 
 pub mod asteroid;
 pub mod satelite;

--- a/src/calculus/mod.rs
+++ b/src/calculus/mod.rs
@@ -1,57 +1,17 @@
-//! # Celestial Mechanics Calculus Module
+//! Numerical kernels underpinning high‑precision astronomy.
 //!
-//! This module provides the core algorithms and data structures for high-precision
-//! celestial mechanics calculations in siderust. It is the computational backbone
-//! for planetary, lunar, and solar ephemerides, as well as for general orbital mechanics.
+//! `calculus` gathers algorithms for orbit propagation and analytic ephemerides
+//! used throughout the crate.  The routines aim for reproducibility and are
+//! expressed in terms of strongly typed quantities from [`units`](../units/index.html).
 //!
-//! ## Overview
+//! ## Components
+//! - [`vsop87`]: evaluation of the VSOP87 planetary theory.
+//! - [`elp2000`]: implementation of the ELP2000‑82B lunar solution.
+//! - [`solar`]: solar coordinates and related utilities.
+//! - [`kepler_equations`]: Kepler solvers and state‑vector conversions.
+//! - [`events`]: searches for transits, culminations and other extrema.
 //!
-//! The `calculus` module is organized into several submodules, each responsible for
-//! a specific aspect of astronomical computation. The main functionalities include:
-//!
-//! - **VSOP87 planetary theory**: High-precision positions for the major planets.
-//! - **ELP2000 lunar theory**: Accurate lunar positions using the ELP2000-82B model.
-//! - **Solar calculations**: Solar coordinates and related phenomena.
-//! - **Keplerian orbits**: General elliptical orbit propagation and Kepler's equation solvers.
-//! - **Extremas finding**: Algorithms to find maxima/minima (e.g., culmination, rise/set).
-//!
-//! ## Submodules
-//!
-//! ### `vsop87`
-//! Implements the VSOP87 theory for planetary positions. This includes:
-//! - Data tables for VSOP87A/E (and potentially other variants).
-//! - Efficient evaluation of planetary heliocentric coordinates (X, Y, Z) as a function of time.
-//! - Traits and structures for extensibility and abstraction over different VSOP versions.
-//!
-//! ### `elp2000`
-//! Implements the ELP2000-82B theory for the Moon's position. Features:
-//! - Series expansions for lunar longitude, latitude, and distance.
-//! - Precession corrections and planetary perturbations.
-//! - Functions to compute geocentric ecliptic coordinates of the Moon for any Julian date.
-//!
-//! ### `solar`
-//! Contains algorithms for solar coordinates and related calculations, such as:
-//! - Apparent and mean solar longitude/latitude.
-//! - Solar equations of time, declination, and related phenomena.
-//! - Utility functions for solar ephemerides.
-//!
-//! ### `kepler_equations`
-//! Provides general-purpose routines for elliptical orbit propagation, including:
-//! - Solvers for Kepler's equation (Newton-Raphson and bisection methods).
-//! - Calculation of true anomaly, eccentric anomaly, and orbital positions.
-//! - Conversion between orbital elements and Cartesian coordinates.
-//! - Orbital period and mean motion calculations.
-//!
-//! ### `events`
-//! Algorithms to catch astro events such as:
-//! - Finding upper/lower culmination (transit) times for celestial objects.
-//! - Root-finding and refinement routines for event timing.
-//! - Support for both static and dynamic targets (e.g., stars, planets).
-//!
-//! ## Usage
-//!
-//! This module is intended for internal use by higher-level ephemeris and observer modules,
-//! but its public API can be used directly for custom calculations. For example:
+//! ## Example
 //!
 //! ```rust
 //! use siderust::calculus::kepler_equations::solve_keplers_equation;
@@ -61,37 +21,6 @@
 //! let e = 0.0167;
 //! let eccentric_anomaly = solve_keplers_equation(m, e);
 //! ```
-//!
-//! ## Re-exports
-//!
-//! The module re-exports the most important functions and types from its submodules for convenience:
-//! - `kepler_equations::*`
-//! - `solar::*`
-//! - `find_extremas::*`
-//!
-//! ## References
-//!
-//! - VSOP87: P. Bretagnon & G. Francou, "Planetary theories in rectangular and spherical variables. VSOP87 solutions", A&A 1988
-//! - ELP2000: M. Chapront-Touzé & J. Chapront, "ELP2000-82B: A semi-analytical lunar ephemeris", A&A 1983
-//! - Duffett-Smith & Zwart, "Practical Astronomy with your Calculator or Spreadsheet", 4th ed.
-//!
-//! ## File Structure
-//!
-//! - `vsop87/`         — VSOP87 planetary theory implementation
-//! - `elp2000/`        — ELP2000 lunar theory implementation
-//! - `solar/`          — Solar coordinate calculations
-//! - `kepler_equations/`— General orbital mechanics
-//! - `find_extremas/`  — Extremum-finding algorithms
-//!
-//! ## See Also
-//!
-//! - [`coordinates`](../coordinates/index.html): Coordinate systems and transformations
-//! - [`units`](../units/index.html): Physical and astronomical units
-//! - [`astro`](../astro/index.html): Higher-level astronomical models
-//!
-//! ---
-//! _This module is designed for extensibility and scientific rigor, supporting both
-//! high-precision ephemerides and general-purpose celestial mechanics._
 //!
 
 pub mod solar;

--- a/src/coordinates/mod.rs
+++ b/src/coordinates/mod.rs
@@ -1,56 +1,41 @@
-//! # Coordinates Module
+//! Coordinate types and transformations.
 //!
-//! This module defines strongly typed spherical and cartesian coordinate systems used in astronomy.
-//! The coordinate systems are implemented using Rust's type system with phantom types
-//! to enforce compile-time safety. These phantom types represent the **frame** and **center** of
-//! the coordinate system, ensuring that operations between incompatible coordinate systems are
-//! disallowed unless explicitly converted. Moreover, thanks to the Unit module we can distinguish
-//! the different vector types such as Directions (unitless), Position (Lenght Units) and Velocity
-//! (Velocity Units), that enforce the compiler to validate any transformation of coordinates.
-
-//! ## Key Concepts
-//! - **Position, Direction and Velocity Types**: Both spherical and cartesian coordinates are parameterized
-//!   by a reference center (e.g., `Heliocentric`, `Geocentric`), a reference frame (e.g., `Ecliptic`, `Equatorial`, `ICRS`),
-//!   and a measure unit (`Unitless`, `LengthUnit`, `VelocityUnit`). This ensures that only compatible coordinates can be used together.
-//! - **Phantom Types**: The `Center`, `Frame` and `Unit`types are zero-cost markers that encode coordinate semantics at compile time.
-//! - **Type Safety**: Operations between coordinates are only allowed when their type parameters match, preventing accidental mixing of frames, centers or magnitude.
-//! - **Conversions**: Seamless conversion between spherical and cartesian forms, and between different frames and centers, is provided via `From`/`Into` and the `Transform` trait.
+//! The `coordinates` module defines strongly typed Cartesian and spherical
+//! representations. Phantom markers encode the reference centre, frame and
+//! physical dimension so that mismatched coordinates are rejected at compile
+//! time. Positions, directions and velocities therefore carry their semantics
+//! directly in the type system.
 //!
-//! ## Supported Reference Frames and Centers
-//! - **Frames**: `Equatorial`, `Ecliptic`, `Horizontal`, `ICRS`, `ECEF`
-//! - **Centers**: `Heliocentric`, `Geocentric`, `Barycentric`, `Topocentric`
+//! Conversions between frames and centres are provided through the
+//! [`transform::Transform`] trait, and both representations implement
+//! `From`/`Into` for mutual conversion.
 //!
 //! ## Example
 //! ```rust
-//! use siderust::coordinates::spherical;
-//! use siderust::coordinates::cartesian;
+//! use siderust::coordinates::{cartesian, spherical};
 //! use siderust::coordinates::centers::Heliocentric;
 //! use siderust::coordinates::frames::Ecliptic;
 //! use siderust::units::Degrees;
 //!
-//! // Create a heliocentric ecliptic spherical direction
-//! let spherical = spherical::Direction::<Heliocentric, Ecliptic>::new(
-//!     Degrees::new(45.0), Degrees::new(7.0)
+//! let sph = spherical::Direction::<Heliocentric, Ecliptic>::new(
+//!     Degrees::new(45.0),
+//!     Degrees::new(7.0),
 //! );
-//!
-//! // Convert to cartesian coordinates
-//! let cartesian: cartesian::Direction<Heliocentric, Ecliptic> = (&spherical).into();
-//!
-//! // Convert back to spherical coordinates
-//! let spherical_converted: spherical::Direction<Heliocentric, Ecliptic> = (&cartesian).into();
-//!
-//! println!("Spherical -> Cartesian -> Spherical: {:?}", spherical_converted);
+//! let cart: cartesian::Direction<Heliocentric, Ecliptic> = (&sph).into();
+//! let sph2: spherical::Direction<Heliocentric, Ecliptic> = (&cart).into();
+//! assert_eq!(sph, sph2);
 //! ```
 //!
 //! ## Submodules
-//! - **transform**: Generic transformations between coordinate systems and frames.
-//! - **cartesian**: Cartesian coordinate types and operations.
-//! - **spherical**: Spherical coordinate types and operations.
-//! - **frames**: Reference frame marker types (e.g., `Ecliptic`, `Equatorial`, `ICRS`).
-//! - **centers**: Reference center marker types (e.g., `Heliocentric`, `Geocentric`).
+//! - [`transform`]: generic transformations between coordinate systems and frames.
+//! - [`cartesian`]: Cartesian coordinate types and operations.
+//! - [`spherical`]: spherical coordinate types and operations.
+//! - [`frames`]: reference-frame marker types (e.g. `Ecliptic`, `Equatorial`, `ICRS`).
+//! - [`centers`]: reference-centre marker types (e.g. `Heliocentric`, `Geocentric`).
 
 pub mod transform;
 pub mod cartesian;
 pub mod spherical;
 pub mod frames;
 pub mod centers;
+

--- a/src/observatories/mod.rs
+++ b/src/observatories/mod.rs
@@ -1,7 +1,9 @@
-//! # Observatory Catalog Module
+//! Catalogue of observatory locations.
 //!
-//! This module provides a set of constant definitions for well-known observatories,
-//! represented by their geographic position. (see [`crate::coordinates::spherical::position::Geographic`]).
+//! The constants in this module describe well‑known facilities by their WGS‑84
+//! longitude, latitude and altitude using [`Geographic`]
+//! coordinates.  Values are `const` so they may be used in compile‑time
+//! calculations or embedded contexts.
 
 use crate::coordinates::spherical::position::Geographic;
 use crate::units::{Degrees, Kilometers};

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -1,20 +1,14 @@
-//! Astronomical target representation
+//! Time‑stamped celestial targets.
 //!
-//! This module defines [`Target`], a lightweight container that couples a position
-//! with the time at which the target was seen at that position, together with an optional
-//! proper‑motion model.  It is deliberately generic over the coordinate type so
-//! it can be reused with Cartesian/Spherical equatorial/ecliptic/icrs.
+//! [`Target<T>`] couples a coordinate with the epoch at which it is valid and,
+//! optionally, a linear proper‑motion model.  The generic coordinate allows the
+//! same structure to describe stars, planets or static catalog entries while
+//! remaining allocation‑free.
 //!
-//! The design goals are:
-//! * **Zero‑cost abstraction** – All helper constructors are `const`, allowing
-//!   compile‑time evaluation when all arguments are known at build time.
-//! * **Flexibility** – The generic parameter `T` lets client code choose any
-//!   position type that implements the required operations.
-//! * **Clarity** – Specific helpers (`new`, `new_static`, `new_raw`) make the
-//!   author’s intent explicit: moving target, fixed target, or advanced manual
-//!   construction respectively.
+//! Helper constructors (`new`, `new_static` and `new_raw`) are `const` so they
+//! can participate in compile‑time calculations when all inputs are known.
 //!
-//! ## Examples
+//! ## Example
 //! ```rust
 //! use siderust::units::*;
 //! use siderust::targets::Target;

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -1,44 +1,23 @@
-//! # Units Module
+//! Strongly typed physical quantities.
 //!
-//! This module provides a comprehensive set of strongly-typed units and utilities
-//! for astronomical and scientific calculations. It is designed to ensure correctness,
-//! clarity, and ease of use when working with various units of measurement.
+//! The `units` module supplies zero-cost wrappers around primitive values to
+//! encode their physical dimension in the type system. Arithmetic is only
+//! permitted between compatible dimensions, reducing the risk of unit mistakes in
+//! scientific code.
 //!
-//! ## Features
-//! - **Time Units**: Includes representations for Days, Years, Julian Years, and Centuries.
-//! - **Angular Units**: Provides types for Degrees, Radians, DMS (Degrees, Minutes, Seconds), HMS (HourAngles, Minutes, Seconds), and Arcseconds.
-//! - **Length Units**: Includes types for meters and astronomical units (AstronomicalUnits).
-//! - **Velocity Units**: Provides types for meters per second and kilometers per second.
-//! - **Mass Units**: Includes types for kilograms and solar masses.
-//! - **Power Units**: Includes types for watts and solar luminosity.
-//! - **Arithmetic Operations**: Supports arithmetic operations between compatible units, ensuring type safety.
+//! ## Provided dimensions
+//! - [`time`]: days, Julian years and related intervals.
+//! - [`angular`]: degrees, radians, hour angles and arcseconds.
+//! - [`length`]: metres, kilometres and astronomical units.
+//! - [`velocity`], [`mass`], [`power`], [`frequency`] and [`unitless`].
 //!
-//! ## Example Usage
+//! ## Example
 //! ```rust
 //! use siderust::units::*;
-//!
-//! // Angular Units
-//! let degrees = Degrees::new(180.0);
-//! let radians = degrees.to::<Radian>();
-//! let dms = Degrees::from_dms(12, 34, 56.0);
-//!
-//! // Mass Units
-//! let mass_kg = Kilograms::new(5.0);
-//! let mass_solar = SolarMasses::new(2.0);
-//!
-//! // Conversions
-//! let dms_to_decimal = dms.value();
-//!
+//! let angle = Degrees::new(180.0);
+//! let radians = angle.to::<Radians>();
 //! assert_eq!(radians.value(), std::f64::consts::PI);
 //! ```
-//!
-//! ## Modules
-//! - [`time`]: Time-related units and utilities.
-//! - [`angular`]: Angular measurement units and utilities.
-//! - [`length`]: Length units and utilities.
-//! - [`velocity`]: Velocity-related units and utilities.
-//! - [`mass`]: Mass-related units and utilities.
-//! - [`power`]: Power-related units and utilities.
 
 pub mod angular;
 pub mod frequency;


### PR DESCRIPTION
## Summary
- polish module-level Rustdoc across core astronomy modules
- highlight scientific context and improve examples for bodies, coordinates, and units

## Testing
- `cargo test` *(fails: VSOP87 codegen failed: Fetching VSOP87 directory listing)*

------
https://chatgpt.com/codex/tasks/task_e_68986463cc3c8333927f518d4503b0e0