### PR TITLE
Add orbit model examples and update changelog with new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * New C structs: `siderust_mean_motion_orbit_t` and `siderust_conic_orbit_t`
   * New propagation APIs: `siderust_kepler_position_ex`, `siderust_mean_motion_position`, and `siderust_conic_position`
   * New prepared-orbit handle lifecycle: `siderust_prepared_orbit_create`, `siderust_prepared_orbit_position`, and `siderust_prepared_orbit_destroy`
+  * New model-aware frame/horizontal transform exports for C/C++ adapter parity, including `*_transform_frame_model` and `*_to_horizontal_model` entry points
 * New type-level IAU nutation model markers in `astro::nutation`: `Iau2000A`, `Iau2000B`, `Iau2006`, and `Iau2006A`, plus shared runtime identifiers via `NutationModelId`.
 * Runtime Earth-orientation model selection via `EarthOrientationModel`, including ergonomic `to_*_model(...)` coordinate transform methods for model-specific rotation paths.
 * New nutation model showcase example `examples/14_nutation_models.rs`, covering default transforms and custom `AstroContext::with_model::<...>()` usage.
+* New orbit showcase example `examples/15_orbit_models.rs`, covering `KeplerianOrbit`, `MeanMotionOrbit`, `ConicOrbit`, and `PreparedOrbit`.
 
 ### Changed
 * `astro::orbit::Orbit` has been renamed to `KeplerianOrbit`, making the elliptic-only semantics explicit across public builders, body constants, examples, and `BodycentricParams`.
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Terminology now consistently uses `argument_of_periapsis` / `arg_periapsis_deg` instead of perihelion-specific naming in both Rust and FFI orbit types.
 * `siderust_kepler_position` is now documented as a legacy FFI entry point; `siderust_kepler_position_ex` should be preferred when the orbit reference center matters.
 * Transform defaults now use `Iau2006A` as `DefaultNutationModel`, while keeping opt-in support for `Iau2000A`, `Iau2000B`, and `Iau2006` through typed model contexts.
+* The `siderust-ffi` surface now exposes the runtime Earth-orientation model selection needed for downstream C and C++ adapters to mirror Rust `AstroContext::with_model::<...>()` workflows.
 
 ### Removed
 * Legacy compatibility namespaces `coordinates::types::direction` and `coordinates::types::position`; use the explicit aliases or the `coordinates::spherical::{direction, position}` modules instead.

--- a/examples/15_orbit_models.rs
+++ b/examples/15_orbit_models.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Orbit model overview.
+//!
+//! Shows:
+//! - `KeplerianOrbit` as the canonical elliptic element set
+//! - `MeanMotionOrbit` for mean-motion-driven propagation
+//! - `ConicOrbit` for elliptic + hyperbolic classification/propagation
+//! - `PreparedOrbit` for repeated fast propagation
+//!
+//! Run with: `cargo run --example 15_orbit_models`
+
+use qtty::*;
+use siderust::time::JulianDate;
+use siderust::{ConicOrbit, KeplerianOrbit, MeanMotionOrbit, PreparedOrbit};
+use std::convert::TryFrom;
+
+fn main() {
+    let jd = JulianDate::new(2_458_850.0);
+
+    println!("=== Orbit Models ===\n");
+    println!("Epoch: {jd}\n");
+
+    let kepler = KeplerianOrbit::new(
+        1.0 * AU,
+        0.0167,
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(102.9),
+        Degrees::new(100.0),
+        JulianDate::J2000,
+    );
+    let kepler_pos = kepler.kepler_position(jd);
+    println!("1. KeplerianOrbit");
+    println!(
+        "   heliocentric position = ({:.12}, {:.12}, {:.12}) AU",
+        kepler_pos.x().value(),
+        kepler_pos.y().value(),
+        kepler_pos.z().value()
+    );
+    println!("   radius = {:.12} AU\n", kepler_pos.distance().value());
+
+    let mean_motion = MeanMotionOrbit::try_new(
+        1.0 * AU,
+        0.0167,
+        Degrees::new(0.0),
+        Degrees::new(0.0),
+        Degrees::new(102.9),
+        0.9856,
+        JulianDate::J2000,
+    )
+    .expect("valid mean-motion orbit");
+    let mm_pos = mean_motion
+        .position_at(jd)
+        .expect("mean-motion propagation should succeed");
+    println!("2. MeanMotionOrbit");
+    println!(
+        "   heliocentric position = ({:.12}, {:.12}, {:.12}) AU",
+        mm_pos.x().value(),
+        mm_pos.y().value(),
+        mm_pos.z().value()
+    );
+    println!("   radius = {:.12} AU\n", mm_pos.distance().value());
+
+    let halley_like = ConicOrbit::try_new(
+        0.586 * AU,
+        0.967,
+        Degrees::new(162.3),
+        Degrees::new(58.4),
+        Degrees::new(111.3),
+        Degrees::new(38.4),
+        JulianDate::J2000,
+    )
+    .expect("valid elliptic conic");
+    let hyperbolic = ConicOrbit::try_new(
+        0.255 * AU,
+        1.2,
+        Degrees::new(122.7),
+        Degrees::new(24.6),
+        Degrees::new(241.8),
+        Degrees::new(12.0),
+        JulianDate::J2000,
+    )
+    .expect("valid hyperbolic conic");
+    let elliptic_pos = halley_like
+        .position_at(jd)
+        .expect("elliptic conic propagation should succeed");
+    let hyperbolic_pos = hyperbolic
+        .position_at(jd)
+        .expect("hyperbolic conic propagation should succeed");
+    println!("3. ConicOrbit");
+    println!("   halley-like kind = {:?}", halley_like.kind());
+    println!("   hyperbolic kind  = {:?}", hyperbolic.kind());
+    println!(
+        "   elliptic radius  = {:.12} AU | hyperbolic radius = {:.12} AU\n",
+        elliptic_pos.distance().value(),
+        hyperbolic_pos.distance().value()
+    );
+
+    let prepared = PreparedOrbit::try_from(kepler).expect("elliptic orbit should prepare");
+    let prepared_pos = prepared.position_at(jd);
+    let delta = ((kepler_pos.x().value() - prepared_pos.x().value()).powi(2)
+        + (kepler_pos.y().value() - prepared_pos.y().value()).powi(2)
+        + (kepler_pos.z().value() - prepared_pos.z().value()).powi(2))
+    .sqrt();
+    println!("4. PreparedOrbit");
+    println!(
+        "   prepared radius = {:.12} AU",
+        prepared_pos.distance().value()
+    );
+    println!("   chord delta vs direct Keplerian = {:.3e}", delta);
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -133,6 +133,15 @@ default `Iau2006A`, abridged `Iau2000B`, and precession-only `Iau2006`.
 cargo run --example 14_nutation_models
 ```
 
+### 15. Orbit Models (`15_orbit_models.rs`)
+Overview of the current orbit APIs: `KeplerianOrbit`, `MeanMotionOrbit`,
+`ConicOrbit`, and `PreparedOrbit`, including elliptic vs hyperbolic conic
+classification and prepared-vs-direct propagation comparison.
+
+```bash
+cargo run --example 15_orbit_models
+```
+
 ---
 
 ## Solar System & Coordinates

--- a/siderust-ffi/include/siderust_ffi.h
+++ b/siderust-ffi/include/siderust_ffi.h
@@ -191,6 +191,25 @@ enum SiderustBody
 typedef int32_t SiderustBody;
 #endif // __cplusplus
 
+// Runtime-selectable Earth-orientation / nutation model preset.
+enum SiderustEarthOrientationModel
+#ifdef __cplusplus
+  : int32_t
+#endif // __cplusplus
+ {
+  // Full IAU 2000A nutation.
+  SIDERUST_EARTH_ORIENTATION_MODEL_IAU2000_A = 1,
+  // Abridged IAU 2000B nutation.
+  SIDERUST_EARTH_ORIENTATION_MODEL_IAU2000_B = 2,
+  // IAU 2006 precession-only profile.
+  SIDERUST_EARTH_ORIENTATION_MODEL_IAU2006 = 3,
+  // High-precision IAU 2006A convention.
+  SIDERUST_EARTH_ORIENTATION_MODEL_IAU2006_A = 4,
+};
+#ifndef __cplusplus
+typedef int32_t SiderustEarthOrientationModel;
+#endif // __cplusplus
+
 // Reference center identifier for C interop.
 enum siderust_center_t
 #ifdef __cplusplus
@@ -1198,6 +1217,16 @@ siderust_status_t siderust_spherical_dir_transform_frame(double polar_deg,
                                                          double jd,
                                                          struct siderust_spherical_dir_t *out);
 
+// Transform a spherical direction using an explicit Earth-orientation model.
+
+siderust_status_t siderust_spherical_dir_transform_frame_model(double polar_deg,
+                                                               double azimuth_deg,
+                                                               siderust_frame_t src_frame,
+                                                               siderust_frame_t dst_frame,
+                                                               double jd,
+                                                               SiderustEarthOrientationModel model,
+                                                               struct siderust_spherical_dir_t *out);
+
 // Transform a spherical direction to the horizontal (alt-az) frame.
 //
 // Requires an observer location (geodetic WGS84) and a Julian Date.
@@ -1210,6 +1239,16 @@ siderust_status_t siderust_spherical_dir_to_horizontal(double polar_deg,
                                                        double jd,
                                                        struct siderust_geodetic_t observer,
                                                        struct siderust_spherical_dir_t *out);
+
+// Transform a spherical direction to Horizontal using an explicit Earth-orientation model.
+
+siderust_status_t siderust_spherical_dir_to_horizontal_model(double polar_deg,
+                                                             double azimuth_deg,
+                                                             siderust_frame_t src_frame,
+                                                             double jd,
+                                                             struct siderust_geodetic_t observer,
+                                                             SiderustEarthOrientationModel model,
+                                                             struct siderust_spherical_dir_t *out);
 
 // Transform a Cartesian unit-vector direction from one frame to another.
 //
@@ -1227,6 +1266,17 @@ siderust_status_t siderust_cartesian_dir_transform_frame(double x,
                                                          double jd,
                                                          struct siderust_cartesian_pos_t *out);
 
+// Transform a Cartesian unit-vector direction using an explicit Earth-orientation model.
+
+siderust_status_t siderust_cartesian_dir_transform_frame_model(double x,
+                                                               double y,
+                                                               double z,
+                                                               siderust_frame_t src_frame,
+                                                               siderust_frame_t dst_frame,
+                                                               double jd,
+                                                               SiderustEarthOrientationModel model,
+                                                               struct siderust_cartesian_pos_t *out);
+
 // Transform a Cartesian position from one frame to another (frame-only, same center).
 //
 // The rotation preserves the vector magnitude.  The `center` field of `pos`
@@ -1239,6 +1289,14 @@ siderust_status_t siderust_cartesian_pos_transform_frame(struct siderust_cartesi
                                                          siderust_frame_t dst_frame,
                                                          double jd,
                                                          struct siderust_cartesian_pos_t *out);
+
+// Transform a Cartesian position using an explicit Earth-orientation model.
+
+siderust_status_t siderust_cartesian_pos_transform_frame_model(struct siderust_cartesian_pos_t pos,
+                                                               siderust_frame_t dst_frame,
+                                                               double jd,
+                                                               SiderustEarthOrientationModel model,
+                                                               struct siderust_cartesian_pos_t *out);
 
 // Create a geodetic position and convert to ECEF Cartesian.
 

--- a/siderust-ffi/src/coordinates.rs
+++ b/siderust-ffi/src/coordinates.rs
@@ -17,7 +17,8 @@ use siderust::coordinates::frames::{
     ReferenceFrame, ECEF, ICRF, ICRS,
 };
 use siderust::coordinates::transform::{
-    DirectionAstroExt, PositionAstroExt, SphericalDirectionAstroExt,
+    DirectionAstroExt, EarthOrientationModel as RustEarthOrientationModel, PositionAstroExt,
+    SphericalDirectionAstroExt,
 };
 use siderust::coordinates::{cartesian, spherical};
 use siderust::time::JulianDate;
@@ -41,6 +42,33 @@ trait SphericalDirProxy {
     fn to_equatorial_mean_of_date(&self, jd: &JulianDate) -> (f64, f64);
     fn to_equatorial_true_of_date(&self, jd: &JulianDate) -> (f64, f64);
     fn to_horizontal(&self, jd: &JulianDate, site: &Geodetic<ECEF>) -> (f64, f64);
+    fn to_icrs_model(&self, jd: &JulianDate, model: RustEarthOrientationModel) -> (f64, f64);
+    fn to_ecliptic_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64);
+    fn to_equatorial_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64);
+    fn to_equatorial_mean_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64);
+    fn to_equatorial_true_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64);
+    fn to_horizontal_model(
+        &self,
+        jd: &JulianDate,
+        site: &Geodetic<ECEF>,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64);
 }
 
 /// Helper: extract (polar_deg, azimuth_deg) from a spherical Direction.
@@ -87,6 +115,73 @@ macro_rules! impl_sph_dir_proxy {
                 let icrs = SphericalDirectionAstroExt::to_frame::<ICRS>(self, jd);
                 let eq_tod =
                     SphericalDirectionAstroExt::to_frame::<EquatorialTrueOfDate>(&icrs, jd);
+                let cart = eq_tod.to_cartesian();
+                let hz = DirectionAstroExt::to_horizontal(&cart, jd, site);
+                let hz_sph = spherical::Direction::from_cartesian(&hz);
+                sph_to_pair(&hz_sph)
+            }
+            fn to_icrs_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let r = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                sph_to_pair(&r)
+            }
+            fn to_ecliptic_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let icrs = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                let r = SphericalDirectionAstroExt::to_frame_model::<EclipticMeanJ2000>(
+                    &icrs, jd, model,
+                );
+                sph_to_pair(&r)
+            }
+            fn to_equatorial_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let icrs = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                let r = SphericalDirectionAstroExt::to_frame_model::<EquatorialMeanJ2000>(
+                    &icrs, jd, model,
+                );
+                sph_to_pair(&r)
+            }
+            fn to_equatorial_mean_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let icrs = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                let r = SphericalDirectionAstroExt::to_frame_model::<EquatorialMeanOfDate>(
+                    &icrs, jd, model,
+                );
+                sph_to_pair(&r)
+            }
+            fn to_equatorial_true_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let icrs = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                let r = SphericalDirectionAstroExt::to_frame_model::<EquatorialTrueOfDate>(
+                    &icrs, jd, model,
+                );
+                sph_to_pair(&r)
+            }
+            fn to_horizontal_model(
+                &self,
+                jd: &JulianDate,
+                site: &Geodetic<ECEF>,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64) {
+                let icrs = SphericalDirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                let eq_tod = SphericalDirectionAstroExt::to_frame_model::<EquatorialTrueOfDate>(
+                    &icrs, jd, model,
+                );
                 let cart = eq_tod.to_cartesian();
                 let hz = DirectionAstroExt::to_horizontal(&cart, jd, site);
                 let hz_sph = spherical::Direction::from_cartesian(&hz);
@@ -197,6 +292,55 @@ pub extern "C" fn siderust_spherical_dir_transform_frame(
     }}
 }
 
+/// Transform a spherical direction using an explicit Earth-orientation model.
+#[no_mangle]
+pub extern "C" fn siderust_spherical_dir_transform_frame_model(
+    polar_deg: f64,
+    azimuth_deg: f64,
+    src_frame: SiderustFrame,
+    dst_frame: SiderustFrame,
+    jd: f64,
+    model: SiderustEarthOrientationModel,
+    out: *mut SiderustSphericalDir,
+) -> SiderustStatus {
+    ffi_guard! {{
+        if out.is_null() {
+            return SiderustStatus::NullPointer;
+        }
+
+        let dir = match make_sph_dir_in_frame(src_frame, polar_deg, azimuth_deg) {
+            Ok(d) => d,
+            Err(e) => return e,
+        };
+
+        let jd_val = JulianDate::new(jd);
+        let model = model.to_rust();
+
+        let (out_polar, out_azimuth) = match dst_frame {
+            SiderustFrame::ICRS => dir.to_icrs_model(&jd_val, model),
+            SiderustFrame::EclipticMeanJ2000 => dir.to_ecliptic_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanJ2000 => dir.to_equatorial_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanOfDate => {
+                dir.to_equatorial_mean_of_date_model(&jd_val, model)
+            }
+            SiderustFrame::EquatorialTrueOfDate => {
+                dir.to_equatorial_true_of_date_model(&jd_val, model)
+            }
+            SiderustFrame::Horizontal => return SiderustStatus::InvalidFrame,
+            _ => return SiderustStatus::InvalidFrame,
+        };
+
+        unsafe {
+            *out = SiderustSphericalDir {
+                polar_deg: out_polar,
+                azimuth_deg: out_azimuth,
+                frame: dst_frame,
+            };
+        }
+        SiderustStatus::Ok
+    }}
+}
+
 /// Transform a spherical direction to the horizontal (alt-az) frame.
 ///
 /// Requires an observer location (geodetic WGS84) and a Julian Date.
@@ -237,6 +381,42 @@ pub extern "C" fn siderust_spherical_dir_to_horizontal(
     }}
 }
 
+/// Transform a spherical direction to Horizontal using an explicit Earth-orientation model.
+#[no_mangle]
+pub extern "C" fn siderust_spherical_dir_to_horizontal_model(
+    polar_deg: f64,
+    azimuth_deg: f64,
+    src_frame: SiderustFrame,
+    jd: f64,
+    observer: SiderustGeodetict,
+    model: SiderustEarthOrientationModel,
+    out: *mut SiderustSphericalDir,
+) -> SiderustStatus {
+    ffi_guard! {{
+        if out.is_null() {
+            return SiderustStatus::NullPointer;
+        }
+
+        let dir = match make_sph_dir_in_frame(src_frame, polar_deg, azimuth_deg) {
+            Ok(d) => d,
+            Err(e) => return e,
+        };
+
+        let jd_val = JulianDate::new(jd);
+        let site = observer.to_rust();
+        let (az, alt) = dir.to_horizontal_model(&jd_val, &site, model.to_rust());
+
+        unsafe {
+            *out = SiderustSphericalDir {
+                polar_deg: alt,
+                azimuth_deg: az,
+                frame: SiderustFrame::Horizontal,
+            };
+        }
+        SiderustStatus::Ok
+    }}
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Cartesian Direction, frame transforms
 // ═══════════════════════════════════════════════════════════════════════════
@@ -250,6 +430,27 @@ trait CartesianDirProxy {
     fn to_equatorial_j2000(&self, jd: &JulianDate) -> (f64, f64, f64);
     fn to_equatorial_mean_of_date(&self, jd: &JulianDate) -> (f64, f64, f64);
     fn to_equatorial_true_of_date(&self, jd: &JulianDate) -> (f64, f64, f64);
+    fn to_icrs_model(&self, jd: &JulianDate, model: RustEarthOrientationModel) -> (f64, f64, f64);
+    fn to_ecliptic_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_mean_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_true_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
 }
 
 #[inline]
@@ -283,6 +484,53 @@ macro_rules! impl_cart_dir_proxy {
                 let icrs = DirectionAstroExt::to_frame::<ICRS>(self, jd);
                 cart_dir_to_triple(&DirectionAstroExt::to_frame::<EquatorialTrueOfDate>(
                     &icrs, jd,
+                ))
+            }
+            fn to_icrs_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                cart_dir_to_triple(&DirectionAstroExt::to_frame_model::<ICRS>(self, jd, model))
+            }
+            fn to_ecliptic_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs = DirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                cart_dir_to_triple(&DirectionAstroExt::to_frame_model::<EclipticMeanJ2000>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs = DirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                cart_dir_to_triple(&DirectionAstroExt::to_frame_model::<EquatorialMeanJ2000>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_mean_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs = DirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                cart_dir_to_triple(&DirectionAstroExt::to_frame_model::<EquatorialMeanOfDate>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_true_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs = DirectionAstroExt::to_frame_model::<ICRS>(self, jd, model);
+                cart_dir_to_triple(&DirectionAstroExt::to_frame_model::<EquatorialTrueOfDate>(
+                    &icrs, jd, model,
                 ))
             }
         }
@@ -374,6 +622,58 @@ pub extern "C" fn siderust_cartesian_dir_transform_frame(
     }}
 }
 
+/// Transform a Cartesian unit-vector direction using an explicit Earth-orientation model.
+#[no_mangle]
+pub extern "C" fn siderust_cartesian_dir_transform_frame_model(
+    x: f64,
+    y: f64,
+    z: f64,
+    src_frame: SiderustFrame,
+    dst_frame: SiderustFrame,
+    jd: f64,
+    model: SiderustEarthOrientationModel,
+    out: *mut SiderustCartesianPos,
+) -> SiderustStatus {
+    ffi_guard! {{
+        if out.is_null() {
+            return SiderustStatus::NullPointer;
+        }
+
+        let dir = match make_cart_dir_in_frame(src_frame, x, y, z) {
+            Ok(d) => d,
+            Err(e) => return e,
+        };
+
+        let jd_val = JulianDate::new(jd);
+        let model = model.to_rust();
+
+        let (ox, oy, oz) = match dst_frame {
+            SiderustFrame::ICRS => dir.to_icrs_model(&jd_val, model),
+            SiderustFrame::EclipticMeanJ2000 => dir.to_ecliptic_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanJ2000 => dir.to_equatorial_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanOfDate => {
+                dir.to_equatorial_mean_of_date_model(&jd_val, model)
+            }
+            SiderustFrame::EquatorialTrueOfDate => {
+                dir.to_equatorial_true_of_date_model(&jd_val, model)
+            }
+            _ => return SiderustStatus::InvalidFrame,
+        };
+
+        unsafe {
+            *out = SiderustCartesianPos {
+                x: ox,
+                y: oy,
+                z: oz,
+                frame: dst_frame,
+                center: SiderustCenter::Barycentric,
+                length_unit: SiderustLengthUnit::AU,
+            };
+        }
+        SiderustStatus::Ok
+    }}
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Cartesian Position, frame transforms
 // ═══════════════════════════════════════════════════════════════════════════
@@ -389,6 +689,28 @@ trait CartesianPosProxy {
     fn to_equatorial_j2000(&self, jd: &JulianDate) -> (f64, f64, f64);
     fn to_equatorial_mean_of_date(&self, jd: &JulianDate) -> (f64, f64, f64);
     fn to_equatorial_true_of_date(&self, jd: &JulianDate) -> (f64, f64, f64);
+    fn to_icrs_model(&self, jd: &JulianDate, model: RustEarthOrientationModel) -> (f64, f64, f64);
+    fn to_icrf_model(&self, jd: &JulianDate, model: RustEarthOrientationModel) -> (f64, f64, f64);
+    fn to_ecliptic_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_j2000_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_mean_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
+    fn to_equatorial_true_of_date_model(
+        &self,
+        jd: &JulianDate,
+        model: RustEarthOrientationModel,
+    ) -> (f64, f64, f64);
 }
 
 /// Helper: extract raw (x, y, z) from a Cartesian position.
@@ -434,6 +756,66 @@ macro_rules! impl_cart_pos_proxy {
                     PositionAstroExt::to_frame(self, jd);
                 cart_pos_to_triple(&PositionAstroExt::to_frame::<EquatorialTrueOfDate>(
                     &icrs, jd,
+                ))
+            }
+            fn to_icrs_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<ICRS>(self, jd, model))
+            }
+            fn to_icrf_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs: cartesian::Position<Barycentric, ICRS, AstronomicalUnit> =
+                    PositionAstroExt::to_frame_model(self, jd, model);
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<ICRF>(&icrs, jd, model))
+            }
+            fn to_ecliptic_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs: cartesian::Position<Barycentric, ICRS, AstronomicalUnit> =
+                    PositionAstroExt::to_frame_model(self, jd, model);
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<EclipticMeanJ2000>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_j2000_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs: cartesian::Position<Barycentric, ICRS, AstronomicalUnit> =
+                    PositionAstroExt::to_frame_model(self, jd, model);
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<EquatorialMeanJ2000>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_mean_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs: cartesian::Position<Barycentric, ICRS, AstronomicalUnit> =
+                    PositionAstroExt::to_frame_model(self, jd, model);
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<EquatorialMeanOfDate>(
+                    &icrs, jd, model,
+                ))
+            }
+            fn to_equatorial_true_of_date_model(
+                &self,
+                jd: &JulianDate,
+                model: RustEarthOrientationModel,
+            ) -> (f64, f64, f64) {
+                let icrs: cartesian::Position<Barycentric, ICRS, AstronomicalUnit> =
+                    PositionAstroExt::to_frame_model(self, jd, model);
+                cart_pos_to_triple(&PositionAstroExt::to_frame_model::<EquatorialTrueOfDate>(
+                    &icrs, jd, model,
                 ))
             }
         }
@@ -536,6 +918,56 @@ pub extern "C" fn siderust_cartesian_pos_transform_frame(
         }
         SiderustStatus::Ok
 
+    }}
+}
+
+/// Transform a Cartesian position using an explicit Earth-orientation model.
+#[no_mangle]
+pub extern "C" fn siderust_cartesian_pos_transform_frame_model(
+    pos: SiderustCartesianPos,
+    dst_frame: SiderustFrame,
+    jd: f64,
+    model: SiderustEarthOrientationModel,
+    out: *mut SiderustCartesianPos,
+) -> SiderustStatus {
+    ffi_guard! {{
+        if out.is_null() {
+            return SiderustStatus::NullPointer;
+        }
+
+        let proxy = match make_cart_pos_in_frame(pos.frame, pos.x, pos.y, pos.z) {
+            Ok(p) => p,
+            Err(e) => return e,
+        };
+
+        let jd_val = JulianDate::new(jd);
+        let model = model.to_rust();
+
+        let (ox, oy, oz) = match dst_frame {
+            SiderustFrame::ICRS => proxy.to_icrs_model(&jd_val, model),
+            SiderustFrame::ICRF => proxy.to_icrf_model(&jd_val, model),
+            SiderustFrame::EclipticMeanJ2000 => proxy.to_ecliptic_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanJ2000 => proxy.to_equatorial_j2000_model(&jd_val, model),
+            SiderustFrame::EquatorialMeanOfDate => {
+                proxy.to_equatorial_mean_of_date_model(&jd_val, model)
+            }
+            SiderustFrame::EquatorialTrueOfDate => {
+                proxy.to_equatorial_true_of_date_model(&jd_val, model)
+            }
+            _ => return SiderustStatus::InvalidFrame,
+        };
+
+        unsafe {
+            *out = SiderustCartesianPos {
+                x: ox,
+                y: oy,
+                z: oz,
+                frame: dst_frame,
+                center: pos.center,
+                length_unit: pos.length_unit,
+            };
+        }
+        SiderustStatus::Ok
     }}
 }
 
@@ -1183,6 +1615,38 @@ mod tests {
         assert_eq!(s, SiderustStatus::NullPointer);
     }
 
+    #[test]
+    fn spherical_dir_model_variant_changes_true_of_date() {
+        let mut with_nutation = empty_dir();
+        let mut precession_only = empty_dir();
+        let jd = 2_458_850.0;
+
+        let s1 = siderust_spherical_dir_transform_frame_model(
+            30.0,
+            100.0,
+            SiderustFrame::ICRS,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006A,
+            &mut with_nutation,
+        );
+        let s2 = siderust_spherical_dir_transform_frame_model(
+            30.0,
+            100.0,
+            SiderustFrame::ICRS,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006,
+            &mut precession_only,
+        );
+
+        assert_eq!(s1, SiderustStatus::Ok);
+        assert_eq!(s2, SiderustStatus::Ok);
+        let delta = (with_nutation.polar_deg - precession_only.polar_deg).abs()
+            + (with_nutation.azimuth_deg - precession_only.azimuth_deg).abs();
+        assert!(delta > 1e-10);
+    }
+
     // ── To horizontal ─────────────────────────────────────────────────────
 
     #[test]
@@ -1243,6 +1707,22 @@ mod tests {
             ptr::null_mut(),
         );
         assert_eq!(s, SiderustStatus::NullPointer);
+    }
+
+    #[test]
+    fn spherical_dir_horizontal_model_variant_succeeds() {
+        let mut out = empty_dir();
+        let s = siderust_spherical_dir_to_horizontal_model(
+            38.8,
+            279.2,
+            SiderustFrame::ICRS,
+            J2000,
+            paris_observer(),
+            SiderustEarthOrientationModel::Iau2000B,
+            &mut out,
+        );
+        assert_eq!(s, SiderustStatus::Ok);
+        assert_eq!(out.frame, SiderustFrame::Horizontal);
     }
 
     // ── Geodetic to ECEF ─────────────────────────────────────────────────
@@ -1458,6 +1938,42 @@ mod tests {
         assert_eq!(s, SiderustStatus::NullPointer);
     }
 
+    #[test]
+    fn cartesian_dir_model_variant_changes_true_of_date() {
+        let mut with_nutation = empty_cart();
+        let mut precession_only = empty_cart();
+        let jd = 2_458_850.0;
+
+        let s1 = siderust_cartesian_dir_transform_frame_model(
+            0.6,
+            -0.3,
+            0.74,
+            SiderustFrame::ICRS,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006A,
+            &mut with_nutation,
+        );
+        let s2 = siderust_cartesian_dir_transform_frame_model(
+            0.6,
+            -0.3,
+            0.74,
+            SiderustFrame::ICRS,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006,
+            &mut precession_only,
+        );
+
+        assert_eq!(s1, SiderustStatus::Ok);
+        assert_eq!(s2, SiderustStatus::Ok);
+        let delta = ((with_nutation.x - precession_only.x).powi(2)
+            + (with_nutation.y - precession_only.y).powi(2)
+            + (with_nutation.z - precession_only.z).powi(2))
+        .sqrt();
+        assert!(delta > 1e-10);
+    }
+
     // ── Cartesian position frame transforms ──────────────────────────────
 
     fn earth_pos_icrs() -> SiderustCartesianPos {
@@ -1602,6 +2118,37 @@ mod tests {
             ptr::null_mut(),
         );
         assert_eq!(s, SiderustStatus::NullPointer);
+    }
+
+    #[test]
+    fn cartesian_pos_model_variant_changes_true_of_date() {
+        let pos = earth_pos_icrs();
+        let mut with_nutation = empty_cart();
+        let mut precession_only = empty_cart();
+        let jd = 2_458_850.0;
+
+        let s1 = siderust_cartesian_pos_transform_frame_model(
+            pos,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006A,
+            &mut with_nutation,
+        );
+        let s2 = siderust_cartesian_pos_transform_frame_model(
+            pos,
+            SiderustFrame::EquatorialTrueOfDate,
+            jd,
+            SiderustEarthOrientationModel::Iau2006,
+            &mut precession_only,
+        );
+
+        assert_eq!(s1, SiderustStatus::Ok);
+        assert_eq!(s2, SiderustStatus::Ok);
+        let delta = ((with_nutation.x - precession_only.x).powi(2)
+            + (with_nutation.y - precession_only.y).powi(2)
+            + (with_nutation.z - precession_only.z).powi(2))
+        .sqrt();
+        assert!(delta > 1e-10);
     }
 
     // ── Cartesian position center transforms ─────────────────────────────

--- a/siderust-ffi/src/types.rs
+++ b/siderust-ffi/src/types.rs
@@ -58,6 +58,7 @@ use siderust::coordinates::centers::{
     OrbitReferenceCenter as RustOrbitRefCenter,
 };
 use siderust::coordinates::frames::ECEF;
+use siderust::coordinates::transform::EarthOrientationModel;
 use tempoch::{Interval, JulianDate, ModifiedJulianDate, Period, MJD};
 
 // Re-export tempoch-ffi types so the generated header can reference them.
@@ -178,6 +179,32 @@ pub enum SiderustCenter {
     Topocentric = 4,
     /// Centre of a specific body.
     Bodycentric = 5,
+}
+
+/// Runtime-selectable Earth-orientation / nutation model preset.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SiderustEarthOrientationModel {
+    /// Full IAU 2000A nutation.
+    Iau2000A = 1,
+    /// Abridged IAU 2000B nutation.
+    Iau2000B = 2,
+    /// IAU 2006 precession-only profile.
+    Iau2006 = 3,
+    /// High-precision IAU 2006A convention.
+    Iau2006A = 4,
+}
+
+impl SiderustEarthOrientationModel {
+    /// Convert to the Rust runtime model enum.
+    pub fn to_rust(self) -> EarthOrientationModel {
+        match self {
+            Self::Iau2000A => EarthOrientationModel::Iau2000A,
+            Self::Iau2000B => EarthOrientationModel::Iau2000B,
+            Self::Iau2006 => EarthOrientationModel::Iau2006,
+            Self::Iau2006A => EarthOrientationModel::Iau2006A,
+        }
+    }
 }
 
 impl SiderustCenter {
@@ -1248,6 +1275,26 @@ mod tests {
         assert!((back.eccentricity - 1.0009).abs() < 1e-10);
     }
 
+    #[test]
+    fn earth_orientation_model_mapping() {
+        assert_eq!(
+            SiderustEarthOrientationModel::Iau2000A.to_rust(),
+            EarthOrientationModel::Iau2000A
+        );
+        assert_eq!(
+            SiderustEarthOrientationModel::Iau2000B.to_rust(),
+            EarthOrientationModel::Iau2000B
+        );
+        assert_eq!(
+            SiderustEarthOrientationModel::Iau2006.to_rust(),
+            EarthOrientationModel::Iau2006
+        );
+        assert_eq!(
+            SiderustEarthOrientationModel::Iau2006A.to_rust(),
+            EarthOrientationModel::Iau2006A
+        );
+    }
+
     // ── SiderustSearchOpts ───────────────────────────────────────────────
 
     #[test]
@@ -1518,6 +1565,11 @@ mod tests {
     #[test]
     fn layout_center_enum() {
         assert_layout!(SiderustCenter, size = 4, align = 4);
+    }
+
+    #[test]
+    fn layout_earth_orientation_model_enum() {
+        assert_layout!(SiderustEarthOrientationModel, size = 4, align = 4);
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces new model-aware coordinate transform APIs to the C/C++ FFI surface, enabling explicit selection of Earth-orientation (nutation/precession) models at runtime and improving parity with Rust workflows. It also adds a new example showcasing orbit models and updates documentation accordingly. The most important changes are:

### FFI API Enhancements: Model-Aware Transforms

* Added new FFI entry points for model-aware frame and horizontal transforms, including `*_transform_frame_model` and `*_to_horizontal_model` functions, allowing explicit selection of Earth-orientation models in coordinate transformations. [[1]](diffhunk://#diff-aaa470d8fdb9524c27e7a482cff03b2c68738604b4b0088089e9b49f143d0bceR1220-R1229) [[2]](diffhunk://#diff-aaa470d8fdb9524c27e7a482cff03b2c68738604b4b0088089e9b49f143d0bceR1243-R1252) [[3]](diffhunk://#diff-aaa470d8fdb9524c27e7a482cff03b2c68738604b4b0088089e9b49f143d0bceR1269-R1279) [[4]](diffhunk://#diff-aaa470d8fdb9524c27e7a482cff03b2c68738604b4b0088089e9b49f143d0bceR1293-R1300) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R25)
* Introduced the `SiderustEarthOrientationModel` enum to the FFI, providing runtime selection of nutation/precession models (IAU2000A, IAU2000B, IAU2006, IAU2006A) for downstream adapters. [[1]](diffhunk://#diff-aaa470d8fdb9524c27e7a482cff03b2c68738604b4b0088089e9b49f143d0bceR194-R212) [[2]](diffhunk://#diff-0e63ddada13659324eacb970c40c88b9ac4e74ce7e27e01ef3bb95b4fdc9f34dR184-R209) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR34)

### Rust FFI Type Support and Testing

* Implemented the Rust-side `SiderustEarthOrientationModel` enum with conversion to the internal `EarthOrientationModel`, and added unit tests to verify correct mapping and FFI layout. [[1]](diffhunk://#diff-0e63ddada13659324eacb970c40c88b9ac4e74ce7e27e01ef3bb95b4fdc9f34dR184-R209) [[2]](diffhunk://#diff-0e63ddada13659324eacb970c40c88b9ac4e74ce7e27e01ef3bb95b4fdc9f34dR1278-R1297) [[3]](diffhunk://#diff-0e63ddada13659324eacb970c40c88b9ac4e74ce7e27e01ef3bb95b4fdc9f34dR1570-R1574) [[4]](diffhunk://#diff-0e63ddada13659324eacb970c40c88b9ac4e74ce7e27e01ef3bb95b4fdc9f34dR61)

### Documentation and Examples

* Added a new example `examples/15_orbit_models.rs` demonstrating the usage of `KeplerianOrbit`, `MeanMotionOrbit`, `ConicOrbit`, and `PreparedOrbit`, including comparisons of propagation methods. [[1]](diffhunk://#diff-fc9a949031f0a47dec7df21ff1a78b75f9e7e4987b0bb44eb8557b8e91896a82R1-R113) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R25)
* Updated `examples/README.md` and `CHANGELOG.md` to document the new APIs, example, and FFI model selection capabilities. [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R136-R144) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R25) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR34)