### PR TITLE
    fix: add siderust_outside_azimuth_range to siderust-ffi C ABI

### DIFF
--- a/siderust-ffi/include/siderust_ffi.h
+++ b/siderust-ffi/include/siderust_ffi.h
@@ -1396,6 +1396,17 @@ siderust_status_t siderust_in_azimuth_range(struct siderust_subject_t subject,
                                             tempoch_period_mjd_t **out,
                                             uintptr_t *count);
 
+// Periods when a subject's azimuth is outside [min_deg, max_deg].
+
+siderust_status_t siderust_outside_azimuth_range(struct siderust_subject_t subject,
+                                                 struct siderust_geodetic_t observer,
+                                                 tempoch_period_mjd_t window,
+                                                 double min_deg,
+                                                 double max_deg,
+                                                 struct siderust_search_opts_t opts,
+                                                 tempoch_period_mjd_t **out,
+                                                 uintptr_t *count);
+
 // Create a generic target from the tagged target payload.
 //
 // This is the canonical constructor for the compact FFI target ABI. Existing

--- a/siderust-ffi/src/subject.rs
+++ b/siderust-ffi/src/subject.rs
@@ -22,7 +22,9 @@ use crate::error::SiderustStatus;
 use crate::types::*;
 use qtty::angular::Degrees;
 use qtty::*;
-use siderust::calculus::azimuth::{azimuth_crossings, azimuth_extrema, in_azimuth_range, outside_azimuth_range};
+use siderust::calculus::azimuth::{
+    azimuth_crossings, azimuth_extrema, in_azimuth_range, outside_azimuth_range,
+};
 use siderust::AltitudePeriodsProvider;
 use siderust::AzimuthProvider;
 use tempoch::ModifiedJulianDate;

--- a/siderust-ffi/src/subject.rs
+++ b/siderust-ffi/src/subject.rs
@@ -22,7 +22,7 @@ use crate::error::SiderustStatus;
 use crate::types::*;
 use qtty::angular::Degrees;
 use qtty::*;
-use siderust::calculus::azimuth::{azimuth_crossings, azimuth_extrema, in_azimuth_range};
+use siderust::calculus::azimuth::{azimuth_crossings, azimuth_extrema, in_azimuth_range, outside_azimuth_range};
 use siderust::AltitudePeriodsProvider;
 use siderust::AzimuthProvider;
 use tempoch::ModifiedJulianDate;
@@ -319,6 +319,40 @@ pub extern "C" fn siderust_in_azimuth_range(
         dispatch_subject!(subject, |p| {
             periods_to_c(
                 in_azimuth_range(
+                    p,
+                    &observer.to_rust(),
+                    window,
+                    Degrees::new(min_deg),
+                    Degrees::new(max_deg),
+                    opts.to_rust(),
+                ),
+                out,
+                count,
+            )
+        })
+    }}
+}
+
+/// Periods when a subject's azimuth is outside [min_deg, max_deg].
+#[no_mangle]
+pub extern "C" fn siderust_outside_azimuth_range(
+    subject: SiderustSubject,
+    observer: SiderustGeodetict,
+    window: TempochPeriodMjd,
+    min_deg: f64,
+    max_deg: f64,
+    opts: SiderustSearchOpts,
+    out: *mut *mut TempochPeriodMjd,
+    count: *mut usize,
+) -> SiderustStatus {
+    ffi_guard! {{
+        let window = match window_from_c(window) {
+            Ok(w) => w,
+            Err(e) => return e,
+        };
+        dispatch_subject!(subject, |p| {
+            periods_to_c(
+                outside_azimuth_range(
                     p,
                     &observer.to_rust(),
                     window,


### PR DESCRIPTION
    The C++ wrapper azimuth.hpp calls siderust_outside_azimuth_range but the
    function was missing from the FFI Rust source and the generated C header.

    - Import outside_azimuth_range in subject.rs alongside in_azimuth_range
    - Add siderust_outside_azimuth_range #[no_mangle] extern C fn (mirrors siderust_in_azimuth_range, delegates to outside_azimuth_range)
    - Add matching declaration to siderust_ffi.h

    This unblocks compilation and all 216 C++ tests for siderust-cpp v0.3.0.