### PR TITLE
ci: exclude benchmark targets from regular CI

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -19,6 +19,9 @@ env:
   CARGO_TERM_COLOR: always
   # Deterministic CI: do not download multi-GB JPL BSP files during --all-features.
   SIDERUST_JPL_STUB: all
+  # Regular CI should cover library, binaries, examples, and tests without compiling
+  # Criterion benchmark targets. Benchmarks remain available through `cargo bench`.
+  CARGO_CI_TARGETS: "--lib --bins --tests --examples"
 
 jobs:
   check:
@@ -29,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --workspace --all-targets --all-features
+      - run: cargo check --workspace $CARGO_CI_TARGETS --all-features
 
   fmt:
     name: Format
@@ -53,7 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace $CARGO_CI_TARGETS --all-features -- -D warnings
 
   test:
     name: Test (all features)
@@ -63,7 +66,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test --workspace --all-targets --all-features
+      - run: cargo test --workspace $CARGO_CI_TARGETS --all-features
       - run: cargo test --doc --workspace --all-features
 
   test-pod:


### PR DESCRIPTION
## Summary

- Exclude Cargo benchmark targets from the regular CI `check`, `clippy`, and `test` jobs.
- Keep normal coverage for library, binaries, integration tests, and examples via `--lib --bins --tests --examples`.
- Leave benchmarks available for explicit/manual `cargo bench` runs or a dedicated performance workflow.

## Rationale

The previous `--all-targets` selection compiled Cargo `[[bench]]` targets in normal CI. Those Criterion benchmark targets are expensive and make PR feedback unnecessarily slow.

## Testing

- Not run locally; CI-only workflow change.
- Verified the branch diff is limited to `.github/workflows/github-ci.yml`.