### PR TITLE
Add ergonomic horizontal coordinate transformations

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write   # needed to post PR comments
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/examples/19_horizontal_coordinates.rs
+++ b/examples/19_horizontal_coordinates.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Horizontal Coordinates Example
+//!
+//! Demonstrates equatorial ↔ horizontal transforms for spherical and cartesian
+//! directions and positions, with round-trip checks.
+//!
+//! Positions use **mean-of-date + GMST** via [`.transform(jd)`]. Directions use
+//! **true-of-date + GAST** via [`.to_horizontal`] / [`.to_equatorial`] (observer
+//! site passed explicitly). See `doc/frames_and_centers.md` for frame details.
+//!
+//! Run with: `cargo run --example 19_horizontal_coordinates`
+#![allow(clippy::print_stdout)]
+
+use siderust::catalogs::observatories::ROQUE_DE_LOS_MUCHACHOS;
+use siderust::coordinates::cartesian::Position;
+use siderust::coordinates::centers::Topocentric;
+use siderust::coordinates::frames::{EquatorialMeanOfDate, Horizontal};
+use siderust::coordinates::spherical;
+use siderust::coordinates::transform::{DirectionAstroExt, SphericalDirectionAstroExt, Transform};
+use siderust::qtty::*;
+use siderust::time::JulianDate;
+
+fn main() {
+    println!("=== Horizontal Coordinates Example ===\n");
+
+    let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
+    let jd = JulianDate::new(2_459_015.5); // 2020-01-01 12:00 TT
+
+    // Sirius apparent equatorial coordinates (degrees).
+    let ra = Degrees::new(101.287);
+    let dec = Degrees::new(-16.716);
+    let distance = 384_400.0 * KM;
+
+    println!("Observer: {}", ROQUE_DE_LOS_MUCHACHOS.name);
+    println!("Epoch (TT): {jd:.6}\n");
+
+    // =========================================================================
+    // 1. Spherical positions (EquatorialMeanOfDate → Horizontal, GMST)
+    // =========================================================================
+    println!("1. SPHERICAL POSITIONS (GMST, .transform)");
+    println!("-------------------------------------------");
+
+    let eq_mod_dir = spherical::direction::EquatorialMeanOfDate::new(ra, dec);
+    let eq_sph = eq_mod_dir.position_with_params::<Topocentric, Kilometer>(site, distance);
+
+    println!("EquatorialMeanOfDate (topocentric):");
+    println!(
+        "  RA = {:.4}, Dec = {:.4}, dist = {}",
+        eq_sph.ra(),
+        eq_sph.dec(),
+        eq_sph.distance
+    );
+
+    let hz_sph: spherical::Position<Topocentric, Horizontal, Kilometer> = eq_sph.transform(jd);
+    let back_sph: spherical::Position<Topocentric, EquatorialMeanOfDate, Kilometer> =
+        hz_sph.transform(jd);
+
+    println!("Horizontal:");
+    println!(
+        "  Alt = {:.4}, Az = {:.4}, dist = {}",
+        hz_sph.alt(),
+        hz_sph.az(),
+        hz_sph.distance
+    );
+    println!(
+        "  Round-trip distance residual: {}\n",
+        (eq_sph.distance - back_sph.distance).abs()
+    );
+
+    // =========================================================================
+    // 2. Cartesian positions (EquatorialMeanOfDate → Horizontal, GMST)
+    // =========================================================================
+    println!("2. CARTESIAN POSITIONS (GMST, .transform)");
+    println!("-------------------------------------------");
+
+    let eq_cart = Position::<Topocentric, EquatorialMeanOfDate, Kilometer>::from_spherical(&eq_sph);
+
+    let hz_cart: Position<Topocentric, Horizontal, Kilometer> = eq_cart.transform(jd);
+    let back_cart: Position<Topocentric, EquatorialMeanOfDate, Kilometer> = hz_cart.transform(jd);
+
+    println!(
+        "EquatorialMeanOfDate (cartesian): dist = {}",
+        eq_cart.distance()
+    );
+    println!(
+        "Horizontal (cartesian): Alt = {:.4}, Az = {:.4}, dist = {}",
+        hz_cart.to_spherical().alt(),
+        hz_cart.to_spherical().az(),
+        hz_cart.distance()
+    );
+    println!(
+        "  Round-trip distance residual: {}\n",
+        (eq_cart.distance() - back_cart.distance()).abs()
+    );
+
+    // =========================================================================
+    // 3. Spherical directions (EquatorialTrueOfDate → Horizontal, GAST)
+    // =========================================================================
+    println!("3. SPHERICAL DIRECTIONS (GAST, .to_horizontal / .to_equatorial)");
+    println!("----------------------------------------------------------------");
+
+    let eq_tod = spherical::direction::EquatorialTrueOfDate::new(ra, dec);
+
+    println!("EquatorialTrueOfDate:");
+    println!("  RA = {:.4}, Dec = {:.4}", eq_tod.ra(), eq_tod.dec());
+
+    let hz_tod = eq_tod.to_horizontal(&jd, &site);
+    let back_tod = hz_tod.to_equatorial(&jd, &site);
+
+    println!("Horizontal:");
+    println!("  Alt = {:.4}, Az = {:.4}", hz_tod.alt(), hz_tod.az());
+    println!(
+        "  Round-trip angular separation: {}\n",
+        eq_tod.angular_separation(&back_tod)
+    );
+
+    // =========================================================================
+    // 4. Cartesian directions (EquatorialTrueOfDate → Horizontal, GAST)
+    // =========================================================================
+    println!("4. CARTESIAN DIRECTIONS (GAST, .to_horizontal / .to_equatorial)");
+    println!("-----------------------------------------------------------------");
+
+    let eq_cart_dir = eq_tod.to_cartesian();
+    let hz_cart_dir = eq_cart_dir.to_horizontal(&jd, &site);
+    let back_cart_dir = hz_cart_dir.to_equatorial(&jd, &site);
+
+    let hz_cart_sph = hz_cart_dir.to_spherical();
+    let back_cart_sph = back_cart_dir.to_spherical();
+
+    println!("Horizontal (cartesian):");
+    println!(
+        "  Alt = {:.4}, Az = {:.4}",
+        hz_cart_sph.alt(),
+        hz_cart_sph.az()
+    );
+    println!(
+        "  Round-trip angular separation: {}\n",
+        eq_tod.angular_separation(&back_cart_sph)
+    );
+
+    println!("=== Example Complete ===");
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Feature-gated examples list the required feature in the command.
 - `04_all_center_conversions`: supported center shifts and round-trip checks.
 - `13_coordinate_operations`: angular separation, distances, and displacement algebra.
 - `14_nutation_models`: default and custom nutation-model transform paths.
+- `19_horizontal_coordinates`: equatorial ↔ horizontal for spherical/cartesian directions and positions.
 
 ```bash
 cargo run --example 01_basic_coordinates
@@ -24,6 +25,7 @@ cargo run --example 03_all_frames_conversions
 cargo run --example 04_all_center_conversions
 cargo run --example 13_coordinate_operations
 cargo run --example 14_nutation_models
+cargo run --example 19_horizontal_coordinates
 ```
 
 ## Observing Workflows

--- a/src/coordinates/transform/ext.rs
+++ b/src/coordinates/transform/ext.rs
@@ -73,12 +73,13 @@
 
 use crate::coordinates::cartesian::{Direction, Position, Vector};
 use crate::coordinates::centers::{Geodetic, ReferenceCenter};
-use crate::coordinates::frames::{ReferenceFrame, ECEF};
+use crate::coordinates::frames::{EquatorialTrueOfDate, Horizontal, ReferenceFrame, ECEF};
 use crate::coordinates::spherical;
 use crate::coordinates::transform::centers::TransformCenter;
 use crate::coordinates::transform::context::{
     AstroContext, DefaultEop, DefaultEphemeris, TransformContext,
 };
+use crate::coordinates::transform::horizontal::FromHorizontal;
 use crate::coordinates::transform::providers::{
     frame_rotation_with, CenterShiftProvider, FrameRotationProvider,
 };
@@ -138,11 +139,7 @@ pub trait DirectionAstroExt<F: ReferenceFrame> {
     /// value.
     ///
     /// [`to_horizontal_precise`]: Self::to_horizontal_precise
-    fn to_horizontal(
-        &self,
-        jd_tt: &JulianDate,
-        site: &Geodetic<ECEF>,
-    ) -> Direction<crate::coordinates::frames::Horizontal>
+    fn to_horizontal(&self, jd_tt: &JulianDate, site: &Geodetic<ECEF>) -> Direction<Horizontal>
     where
         Self: crate::coordinates::transform::horizontal::ToHorizontal,
     {
@@ -162,13 +159,46 @@ pub trait DirectionAstroExt<F: ReferenceFrame> {
         jd_tt: &JulianDate,
         jd_ut1: &JulianDate,
         site: &Geodetic<ECEF>,
-    ) -> Direction<crate::coordinates::frames::Horizontal>
+    ) -> Direction<Horizontal>
     where
         Self: crate::coordinates::transform::horizontal::ToHorizontal,
     {
         crate::coordinates::transform::horizontal::ToHorizontal::to_horizontal(
             self, jd_ut1, jd_tt, site,
         )
+    }
+
+    /// Converts this horizontal direction to equatorial (true of date) using TT only.
+    ///
+    /// UT1 is derived from TT using the context's EOP provider. For sub-second
+    /// precision, prefer [`to_equatorial_precise`] with an explicit UT1 value.
+    ///
+    /// [`to_equatorial_precise`]: Self::to_equatorial_precise
+    fn to_equatorial(
+        &self,
+        jd_tt: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> Direction<EquatorialTrueOfDate>
+    where
+        Self: FromHorizontal,
+    {
+        let ctx: AstroContext<DefaultEphemeris, DefaultEop> = AstroContext::default();
+        let eop = ctx.eop_at_tt(*jd_tt);
+        let jd_ut1 = crate::astro::earth_rotation::jd_ut1_from_tt_eop(*jd_tt, &eop);
+        FromHorizontal::to_equatorial(self, &jd_ut1, jd_tt, site)
+    }
+
+    /// Converts this horizontal direction to equatorial (true of date) with explicit UT1+TT.
+    fn to_equatorial_precise(
+        &self,
+        jd_tt: &JulianDate,
+        jd_ut1: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> Direction<EquatorialTrueOfDate>
+    where
+        Self: FromHorizontal,
+    {
+        FromHorizontal::to_equatorial(self, jd_ut1, jd_tt, site)
     }
 }
 
@@ -218,6 +248,44 @@ pub trait SphericalDirectionAstroExt<F: ReferenceFrame> {
     where
         Ctx: TransformContext,
         (): FrameRotationProvider<F, F2>;
+
+    /// Converts this spherical direction to horizontal coordinates using TT only.
+    fn to_horizontal(
+        &self,
+        jd_tt: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<Horizontal>
+    where
+        Direction<F>: crate::coordinates::transform::horizontal::ToHorizontal;
+
+    /// Converts this spherical direction to horizontal coordinates with explicit UT1+TT.
+    fn to_horizontal_precise(
+        &self,
+        jd_tt: &JulianDate,
+        jd_ut1: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<Horizontal>
+    where
+        Direction<F>: crate::coordinates::transform::horizontal::ToHorizontal;
+
+    /// Converts this horizontal spherical direction to equatorial (true of date) using TT only.
+    fn to_equatorial(
+        &self,
+        jd_tt: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<EquatorialTrueOfDate>
+    where
+        Direction<F>: FromHorizontal;
+
+    /// Converts this horizontal spherical direction to equatorial (true of date) with explicit UT1+TT.
+    fn to_equatorial_precise(
+        &self,
+        jd_tt: &JulianDate,
+        jd_ut1: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<EquatorialTrueOfDate>
+    where
+        Direction<F>: FromHorizontal;
 }
 
 impl<F: ReferenceFrame> SphericalDirectionAstroExt<F> for spherical::Direction<F> {
@@ -241,6 +309,60 @@ impl<F: ReferenceFrame> SphericalDirectionAstroExt<F> for spherical::Direction<F
         let cart: Direction<F> = self.to_cartesian();
         let cart_f2: Direction<F2> = cart.to_frame_with(jd, ctx);
         spherical::Direction::from_cartesian(&cart_f2)
+    }
+
+    fn to_horizontal(
+        &self,
+        jd_tt: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<Horizontal>
+    where
+        Direction<F>: crate::coordinates::transform::horizontal::ToHorizontal,
+    {
+        let cart = self.to_cartesian();
+        let horiz_cart = cart.to_horizontal(jd_tt, site);
+        spherical::Direction::from_cartesian(&horiz_cart)
+    }
+
+    fn to_horizontal_precise(
+        &self,
+        jd_tt: &JulianDate,
+        jd_ut1: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<Horizontal>
+    where
+        Direction<F>: crate::coordinates::transform::horizontal::ToHorizontal,
+    {
+        let cart = self.to_cartesian();
+        let horiz_cart = cart.to_horizontal_precise(jd_tt, jd_ut1, site);
+        spherical::Direction::from_cartesian(&horiz_cart)
+    }
+
+    fn to_equatorial(
+        &self,
+        jd_tt: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<EquatorialTrueOfDate>
+    where
+        Direction<F>: FromHorizontal,
+    {
+        let cart = self.to_cartesian();
+        let equ_cart = DirectionAstroExt::to_equatorial(&cart, jd_tt, site);
+        spherical::Direction::from_cartesian(&equ_cart)
+    }
+
+    fn to_equatorial_precise(
+        &self,
+        jd_tt: &JulianDate,
+        jd_ut1: &JulianDate,
+        site: &Geodetic<ECEF>,
+    ) -> spherical::Direction<EquatorialTrueOfDate>
+    where
+        Direction<F>: FromHorizontal,
+    {
+        let cart = self.to_cartesian();
+        let equ_cart = DirectionAstroExt::to_equatorial_precise(&cart, jd_tt, jd_ut1, site);
+        spherical::Direction::from_cartesian(&equ_cart)
     }
 }
 

--- a/src/coordinates/transform/horizontal.rs
+++ b/src/coordinates/transform/horizontal.rs
@@ -231,6 +231,16 @@ pub trait TopocentricEquatorialExt<U: LengthUnit> {
         jd_ut1: &JulianDate,
         jd_tt: &JulianDate,
     ) -> Position<Topocentric, Horizontal, U>;
+
+    /// Alias for [`to_horizontal_position`](Self::to_horizontal_position).
+    #[inline]
+    fn to_horizontal(
+        &self,
+        jd_ut1: &JulianDate,
+        jd_tt: &JulianDate,
+    ) -> Position<Topocentric, Horizontal, U> {
+        self.to_horizontal_position(jd_ut1, jd_tt)
+    }
 }
 
 impl<U: LengthUnit> TopocentricEquatorialExt<U> for Position<Topocentric, EquatorialTrueOfDate, U> {
@@ -279,6 +289,16 @@ pub trait TopocentricHorizontalExt<U: LengthUnit> {
         jd_ut1: &JulianDate,
         jd_tt: &JulianDate,
     ) -> Position<Topocentric, EquatorialTrueOfDate, U>;
+
+    /// Alias for [`to_equatorial_position`](Self::to_equatorial_position).
+    #[inline]
+    fn to_equatorial(
+        &self,
+        jd_ut1: &JulianDate,
+        jd_tt: &JulianDate,
+    ) -> Position<Topocentric, EquatorialTrueOfDate, U> {
+        self.to_equatorial_position(jd_ut1, jd_tt)
+    }
 }
 
 impl<U: LengthUnit> TopocentricHorizontalExt<U> for Position<Topocentric, Horizontal, U> {

--- a/src/formats/sck.rs
+++ b/src/formats/sck.rs
@@ -112,7 +112,7 @@ pub fn parse_sck(bytes: &[u8]) -> Result<SckKernel, FormatError> {
         ));
     }
     let mut records = Vec::with_capacity(expected);
-    for chunk in payload.chunks_exact(8) {
+    for chunk in payload.as_chunks::<8>().0 {
         records.push(read_f64(chunk));
     }
     Ok(SckKernel { header, records })

--- a/tests/test_horizontal_extension_api.rs
+++ b/tests/test_horizontal_extension_api.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Public-API regression tests for the ergonomic horizontal-coordinate extensions.
+//!
+//! These tests intentionally exercise the convenience methods added by PR #86,
+//! rather than calling the lower-level horizontal transformation traits directly.
+
+use siderust::catalogs::observatories::ROQUE_DE_LOS_MUCHACHOS;
+use siderust::coordinates::cartesian::Position;
+use siderust::coordinates::centers::Topocentric;
+use siderust::coordinates::frames::EquatorialTrueOfDate;
+use siderust::coordinates::spherical;
+use siderust::coordinates::transform::{
+    DirectionAstroExt, SphericalDirectionAstroExt, TopocentricEquatorialExt,
+    TopocentricHorizontalExt,
+};
+use siderust::qtty::*;
+use siderust::time::JulianDate;
+
+const ANGULAR_EPSILON_DEG: f64 = 1e-9;
+const POSITION_EPSILON: f64 = 1e-10;
+
+#[test]
+fn cartesian_direction_horizontal_extensions_round_trip() {
+    let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
+    let jd_ut1 = JulianDate::new(2_459_015.5);
+    let jd_tt = jd_ut1.add_seconds(69.184);
+    let equatorial = spherical::direction::EquatorialTrueOfDate::new(
+        Degrees::new(101.287),
+        Degrees::new(-16.716),
+    )
+    .to_cartesian();
+
+    // TT-only convenience path: UT1 is derived from the default EOP context.
+    let horizontal = DirectionAstroExt::to_horizontal(&equatorial, &jd_tt, &site);
+    let back = DirectionAstroExt::to_equatorial(&horizontal, &jd_tt, &site);
+    let separation = equatorial
+        .to_spherical()
+        .angular_separation(&back.to_spherical())
+        .value();
+    assert!(
+        separation < ANGULAR_EPSILON_DEG,
+        "cartesian TT-only round-trip separation: {separation} deg"
+    );
+
+    // Explicit UT1+TT path.
+    let horizontal =
+        DirectionAstroExt::to_horizontal_precise(&equatorial, &jd_tt, &jd_ut1, &site);
+    let back =
+        DirectionAstroExt::to_equatorial_precise(&horizontal, &jd_tt, &jd_ut1, &site);
+    let separation = equatorial
+        .to_spherical()
+        .angular_separation(&back.to_spherical())
+        .value();
+    assert!(
+        separation < ANGULAR_EPSILON_DEG,
+        "cartesian precise round-trip separation: {separation} deg"
+    );
+}
+
+#[test]
+fn spherical_direction_horizontal_extensions_round_trip() {
+    let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
+    let jd_ut1 = JulianDate::new(2_459_015.5);
+    let jd_tt = jd_ut1.add_seconds(69.184);
+    let equatorial = spherical::direction::EquatorialTrueOfDate::new(
+        Degrees::new(101.287),
+        Degrees::new(-16.716),
+    );
+
+    // TT-only spherical wrapper.
+    let horizontal = SphericalDirectionAstroExt::to_horizontal(&equatorial, &jd_tt, &site);
+    let back = SphericalDirectionAstroExt::to_equatorial(&horizontal, &jd_tt, &site);
+    let separation = equatorial.angular_separation(&back).value();
+    assert!(
+        separation < ANGULAR_EPSILON_DEG,
+        "spherical TT-only round-trip separation: {separation} deg"
+    );
+
+    // Explicit UT1+TT spherical wrapper.
+    let horizontal = SphericalDirectionAstroExt::to_horizontal_precise(
+        &equatorial,
+        &jd_tt,
+        &jd_ut1,
+        &site,
+    );
+    let back =
+        SphericalDirectionAstroExt::to_equatorial_precise(&horizontal, &jd_tt, &jd_ut1, &site);
+    let separation = equatorial.angular_separation(&back).value();
+    assert!(
+        separation < ANGULAR_EPSILON_DEG,
+        "spherical precise round-trip separation: {separation} deg"
+    );
+}
+
+#[test]
+fn topocentric_position_aliases_match_explicit_methods() {
+    let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
+    let jd_ut1 = JulianDate::new(2_459_015.5);
+    let jd_tt = jd_ut1.add_seconds(69.184);
+    let distance = 1_000.0 * KM;
+
+    let equatorial_direction = spherical::direction::EquatorialTrueOfDate::new(
+        Degrees::new(101.287),
+        Degrees::new(-16.716),
+    );
+    let equatorial_spherical = equatorial_direction
+        .position_with_params::<Topocentric, Kilometer>(site, distance);
+    let equatorial =
+        Position::<Topocentric, EquatorialTrueOfDate, Kilometer>::from_spherical(
+            &equatorial_spherical,
+        );
+
+    let horizontal_explicit =
+        TopocentricEquatorialExt::to_horizontal_position(&equatorial, &jd_ut1, &jd_tt);
+    let horizontal_alias = TopocentricEquatorialExt::to_horizontal(&equatorial, &jd_ut1, &jd_tt);
+
+    assert_eq!(horizontal_alias.center_params(), &site);
+    assert!((horizontal_alias.x().value() - horizontal_explicit.x().value()).abs() < POSITION_EPSILON);
+    assert!((horizontal_alias.y().value() - horizontal_explicit.y().value()).abs() < POSITION_EPSILON);
+    assert!((horizontal_alias.z().value() - horizontal_explicit.z().value()).abs() < POSITION_EPSILON);
+
+    let equatorial_explicit =
+        TopocentricHorizontalExt::to_equatorial_position(&horizontal_alias, &jd_ut1, &jd_tt);
+    let equatorial_alias =
+        TopocentricHorizontalExt::to_equatorial(&horizontal_alias, &jd_ut1, &jd_tt);
+
+    assert_eq!(equatorial_alias.center_params(), &site);
+    assert!((equatorial_alias.x().value() - equatorial_explicit.x().value()).abs() < POSITION_EPSILON);
+    assert!((equatorial_alias.y().value() - equatorial_explicit.y().value()).abs() < POSITION_EPSILON);
+    assert!((equatorial_alias.z().value() - equatorial_explicit.z().value()).abs() < POSITION_EPSILON);
+}

--- a/tests/test_horizontal_extension_api.rs
+++ b/tests/test_horizontal_extension_api.rs
@@ -24,8 +24,8 @@ const POSITION_EPSILON: f64 = 1e-10;
 #[test]
 fn cartesian_direction_horizontal_extensions_round_trip() {
     let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
-    let jd_ut1 = JulianDate::new(2_459_015.5);
-    let jd_tt = jd_ut1.add_seconds(69.184);
+    let jd_ut1 = JulianDate::new(2_451_545.0);
+    let jd_tt = JulianDate::new(2_451_545.000_800_741);
     let equatorial = spherical::direction::EquatorialTrueOfDate::new(
         Degrees::new(101.287),
         Degrees::new(-16.716),
@@ -60,8 +60,8 @@ fn cartesian_direction_horizontal_extensions_round_trip() {
 #[test]
 fn spherical_direction_horizontal_extensions_round_trip() {
     let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
-    let jd_ut1 = JulianDate::new(2_459_015.5);
-    let jd_tt = jd_ut1.add_seconds(69.184);
+    let jd_ut1 = JulianDate::new(2_451_545.0);
+    let jd_tt = JulianDate::new(2_451_545.000_800_741);
     let equatorial = spherical::direction::EquatorialTrueOfDate::new(
         Degrees::new(101.287),
         Degrees::new(-16.716),
@@ -91,8 +91,8 @@ fn spherical_direction_horizontal_extensions_round_trip() {
 #[test]
 fn topocentric_position_aliases_match_explicit_methods() {
     let site = ROQUE_DE_LOS_MUCHACHOS.geodetic();
-    let jd_ut1 = JulianDate::new(2_459_015.5);
-    let jd_tt = jd_ut1.add_seconds(69.184);
+    let jd_ut1 = JulianDate::new(2_451_545.0);
+    let jd_tt = JulianDate::new(2_451_545.000_800_741);
     let distance = 1_000.0 * KM;
 
     let equatorial_direction = spherical::direction::EquatorialTrueOfDate::new(

--- a/tests/test_horizontal_extension_api.rs
+++ b/tests/test_horizontal_extension_api.rs
@@ -45,10 +45,8 @@ fn cartesian_direction_horizontal_extensions_round_trip() {
     );
 
     // Explicit UT1+TT path.
-    let horizontal =
-        DirectionAstroExt::to_horizontal_precise(&equatorial, &jd_tt, &jd_ut1, &site);
-    let back =
-        DirectionAstroExt::to_equatorial_precise(&horizontal, &jd_tt, &jd_ut1, &site);
+    let horizontal = DirectionAstroExt::to_horizontal_precise(&equatorial, &jd_tt, &jd_ut1, &site);
+    let back = DirectionAstroExt::to_equatorial_precise(&horizontal, &jd_tt, &jd_ut1, &site);
     let separation = equatorial
         .to_spherical()
         .angular_separation(&back.to_spherical())
@@ -79,12 +77,8 @@ fn spherical_direction_horizontal_extensions_round_trip() {
     );
 
     // Explicit UT1+TT spherical wrapper.
-    let horizontal = SphericalDirectionAstroExt::to_horizontal_precise(
-        &equatorial,
-        &jd_tt,
-        &jd_ut1,
-        &site,
-    );
+    let horizontal =
+        SphericalDirectionAstroExt::to_horizontal_precise(&equatorial, &jd_tt, &jd_ut1, &site);
     let back =
         SphericalDirectionAstroExt::to_equatorial_precise(&horizontal, &jd_tt, &jd_ut1, &site);
     let separation = equatorial.angular_separation(&back).value();
@@ -105,21 +99,26 @@ fn topocentric_position_aliases_match_explicit_methods() {
         Degrees::new(101.287),
         Degrees::new(-16.716),
     );
-    let equatorial_spherical = equatorial_direction
-        .position_with_params::<Topocentric, Kilometer>(site, distance);
-    let equatorial =
-        Position::<Topocentric, EquatorialTrueOfDate, Kilometer>::from_spherical(
-            &equatorial_spherical,
-        );
+    let equatorial_spherical =
+        equatorial_direction.position_with_params::<Topocentric, Kilometer>(site, distance);
+    let equatorial = Position::<Topocentric, EquatorialTrueOfDate, Kilometer>::from_spherical(
+        &equatorial_spherical,
+    );
 
     let horizontal_explicit =
         TopocentricEquatorialExt::to_horizontal_position(&equatorial, &jd_ut1, &jd_tt);
     let horizontal_alias = TopocentricEquatorialExt::to_horizontal(&equatorial, &jd_ut1, &jd_tt);
 
     assert_eq!(horizontal_alias.center_params(), &site);
-    assert!((horizontal_alias.x().value() - horizontal_explicit.x().value()).abs() < POSITION_EPSILON);
-    assert!((horizontal_alias.y().value() - horizontal_explicit.y().value()).abs() < POSITION_EPSILON);
-    assert!((horizontal_alias.z().value() - horizontal_explicit.z().value()).abs() < POSITION_EPSILON);
+    assert!(
+        (horizontal_alias.x().value() - horizontal_explicit.x().value()).abs() < POSITION_EPSILON
+    );
+    assert!(
+        (horizontal_alias.y().value() - horizontal_explicit.y().value()).abs() < POSITION_EPSILON
+    );
+    assert!(
+        (horizontal_alias.z().value() - horizontal_explicit.z().value()).abs() < POSITION_EPSILON
+    );
 
     let equatorial_explicit =
         TopocentricHorizontalExt::to_equatorial_position(&horizontal_alias, &jd_ut1, &jd_tt);
@@ -127,7 +126,13 @@ fn topocentric_position_aliases_match_explicit_methods() {
         TopocentricHorizontalExt::to_equatorial(&horizontal_alias, &jd_ut1, &jd_tt);
 
     assert_eq!(equatorial_alias.center_params(), &site);
-    assert!((equatorial_alias.x().value() - equatorial_explicit.x().value()).abs() < POSITION_EPSILON);
-    assert!((equatorial_alias.y().value() - equatorial_explicit.y().value()).abs() < POSITION_EPSILON);
-    assert!((equatorial_alias.z().value() - equatorial_explicit.z().value()).abs() < POSITION_EPSILON);
+    assert!(
+        (equatorial_alias.x().value() - equatorial_explicit.x().value()).abs() < POSITION_EPSILON
+    );
+    assert!(
+        (equatorial_alias.y().value() - equatorial_explicit.y().value()).abs() < POSITION_EPSILON
+    );
+    assert!(
+        (equatorial_alias.z().value() - equatorial_explicit.z().value()).abs() < POSITION_EPSILON
+    );
 }


### PR DESCRIPTION
## Summary

- expose convenient equatorial true-of-date ↔ horizontal conversions for Cartesian directions
- add equivalent spherical-direction APIs, including TT-only and explicit UT1+TT variants
- support reverse horizontal-to-equatorial conversion through the transformation extension traits
- add a complete horizontal-coordinate example covering spherical and Cartesian positions and directions
- document the new example in `examples/README.md`

## Design notes

The convenience methods derive UT1 from TT through the default EOP context, while the `*_precise` variants accept explicit UT1 and TT for callers requiring tighter Earth-rotation control.

## Validation

- includes round-trip demonstrations in `19_horizontal_coordinates`
- existing CI will validate formatting, compilation, tests, and linting