### PR TITLE
feat(healpix): expose spherical pixel centers

### DIFF
--- a/src/formats/sck.rs
+++ b/src/formats/sck.rs
@@ -112,7 +112,7 @@ pub fn parse_sck(bytes: &[u8]) -> Result<SckKernel, FormatError> {
         ));
     }
     let mut records = Vec::with_capacity(expected);
-    for chunk in payload.chunks_exact(8) {
+    for chunk in payload.as_chunks::<8>().0 {
         records.push(read_f64(chunk));
     }
     Ok(SckKernel { header, records })

--- a/src/healpix/grid.rs
+++ b/src/healpix/grid.rs
@@ -10,6 +10,7 @@
 
 use crate::coordinates::cartesian::Direction;
 use crate::coordinates::frames::ReferenceFrame;
+use crate::coordinates::spherical;
 use crate::healpix::{HealpixError, HealpixIndex, HealpixOrdering, Nside, Result};
 use std::f64::consts::PI;
 
@@ -110,5 +111,27 @@ impl HealpixGrid {
     {
         let (theta, phi) = ring::pixel_to_theta_phi(self, index)?;
         Ok(ring::direction_from_theta_phi(theta, phi))
+    }
+
+    /// Return the center of a pixel as a typed spherical direction.
+    ///
+    /// The returned [`spherical::Direction`] is expressed in the requested
+    /// reference frame type `F`; the grid itself is frame-neutral, so callers
+    /// must choose a frame consistent with the map or grid they are working
+    /// with.
+    ///
+    /// HEALPix describes a center using `theta`, its colatitude, and `phi`, its
+    /// longitude. This method maps those angles directly to Siderust's
+    /// spherical convention: `polar = π/2 - theta` and `azimuth = phi`.
+    /// The result uses the canonical angular ranges supplied by `affn` and
+    /// `qtty`: polar is in `[-90°, +90°]` and azimuth is in `[0°, 360°)`.
+    ///
+    /// No Cartesian conversion is performed.
+    pub fn pixel_center_spherical<F>(&self, index: HealpixIndex) -> Result<spherical::Direction<F>>
+    where
+        F: ReferenceFrame,
+    {
+        let (theta, phi) = ring::pixel_to_theta_phi(self, index)?;
+        Ok(ring::spherical_direction_from_theta_phi(theta, phi))
     }
 }

--- a/src/healpix/ring.rs
+++ b/src/healpix/ring.rs
@@ -15,7 +15,9 @@
 
 use crate::coordinates::cartesian::Direction;
 use crate::coordinates::frames::ReferenceFrame;
+use crate::coordinates::spherical;
 use crate::healpix::{HealpixError, HealpixGrid, HealpixIndex, HealpixOrdering, Result};
+use crate::qtty::{Degree, Radians};
 use std::f64::consts::{FRAC_PI_2, TAU};
 
 pub(super) fn unit_vector_to_pixel(grid: &HealpixGrid, xyz: [f64; 3]) -> Result<HealpixIndex> {
@@ -139,4 +141,14 @@ where
 {
     let sin_theta = theta.sin();
     Direction::<F>::from_array([sin_theta * phi.cos(), sin_theta * phi.sin(), theta.cos()])
+}
+
+/// Map HEALPix colatitude/longitude radians directly to a canonical spherical direction.
+pub(crate) fn spherical_direction_from_theta_phi<F>(theta: f64, phi: f64) -> spherical::Direction<F>
+where
+    F: ReferenceFrame,
+{
+    let polar = Radians::new(FRAC_PI_2 - theta).to::<Degree>();
+    let azimuth = Radians::new(phi).normalize().to::<Degree>().normalize();
+    spherical::Direction::<F>::new_unchecked(polar, azimuth)
 }

--- a/src/healpix/tests.rs
+++ b/src/healpix/tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::coordinates::cartesian::Direction;
 use crate::coordinates::frames;
+use crate::coordinates::spherical;
 use std::f64::consts::PI;
 
 fn ring_grid(nside: u32) -> HealpixGrid {
@@ -40,6 +41,49 @@ fn pixel_centres_roundtrip_through_direction_api() {
         let direction: Direction<frames::Galactic> = grid.pixel_center(index).expect("center");
         assert_eq!(grid.direction_to_pixel(direction).expect("pixel"), index);
     }
+}
+
+#[test]
+fn spherical_pixel_centres_match_cartesian_centres_and_roundtrip() {
+    let grid = ring_grid(8);
+    for raw in [0, 1, 7, 63, 128, 511, grid.npix() - 1] {
+        let index = HealpixIndex::new(raw);
+        let cartesian: Direction<frames::Galactic> = grid.pixel_center(index).expect("center");
+        let spherical: spherical::Direction<frames::Galactic> = grid
+            .pixel_center_spherical(index)
+            .expect("spherical center");
+
+        let from_spherical = spherical.to_cartesian();
+        for (actual, expected) in from_spherical.as_array().iter().zip(cartesian.as_array()) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+        assert_eq!(
+            grid.direction_to_pixel(from_spherical).expect("pixel"),
+            index
+        );
+    }
+}
+
+#[test]
+fn spherical_pixel_centres_are_canonical_at_wrap_and_polar_regions() {
+    let grid = ring_grid(8);
+    for raw in [0, 1, grid.npix() / 2, grid.npix() - 2, grid.npix() - 1] {
+        let center: spherical::Direction<frames::Galactic> = grid
+            .pixel_center_spherical(HealpixIndex::new(raw))
+            .expect("spherical center");
+        assert!((-90.0..=90.0).contains(&center.polar.value()));
+        assert!((0.0..360.0).contains(&center.azimuth.value()));
+    }
+}
+
+#[test]
+fn spherical_pixel_centres_preserve_nested_ordering_behavior() {
+    let grid = HealpixGrid::new(Nside::new(8).expect("valid nside"), HealpixOrdering::Nested)
+        .expect("valid grid");
+    assert!(matches!(
+        grid.pixel_center_spherical::<frames::Galactic>(HealpixIndex::new(0)),
+        Err(HealpixError::UnsupportedOrdering(HealpixOrdering::Nested))
+    ));
 }
 
 #[test]

--- a/src/starlight/validation.rs
+++ b/src/starlight/validation.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Vallés Puig, Ramon
 
-use crate::coordinates::cartesian::Direction;
 use crate::coordinates::frames::Galactic;
 use crate::healpix::{HealpixError, HealpixGrid, HealpixIndex, HealpixMap};
+use crate::qtty::Radian;
 use crate::starlight::{Result, StellarMapError, StellarSurfaceBrightness};
-use std::f64::consts::TAU;
 
 /// Validate that a stellar map contains finite, non-negative values.
 pub fn validate_stellar_map_values(
@@ -174,9 +173,9 @@ pub fn validate_no_longitude_wrap_artifact(
 }
 
 fn pixel_lon_lat_rad(grid: HealpixGrid, index: HealpixIndex) -> Result<(f64, f64)> {
-    let direction: Direction<Galactic> = grid.pixel_center(index)?;
-    let [x, y, z] = direction.as_array();
-    let lon = y.atan2(x).rem_euclid(TAU);
-    let lat = z.clamp(-1.0, 1.0).asin();
-    Ok((lon, lat))
+    let direction = grid.pixel_center_spherical::<Galactic>(index)?;
+    Ok((
+        direction.azimuth.to::<Radian>().value(),
+        direction.polar.to::<Radian>().value(),
+    ))
 }


### PR DESCRIPTION
## Summary
- add `HealpixGrid::pixel_center_spherical` for direct typed spherical pixel centers
- map HEALPix colatitude/longitude through qtty and affn canonical coordinates
- update starlight validation to consume typed spherical centers

## Verification
- `cargo fmt --check`
- `cargo test healpix --lib`
- `cargo clippy --lib --tests -- -D warnings`

The full suite reached its long-running remaining tests after the focused checks passed.