### PR TITLE
Add distinct CTAO North and CTAO South observatories

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,9 @@ use std::path::PathBuf;
 fn symbol_for(name: &str) -> Option<&'static str> {
     match name {
         "El Paranal Observatory" => Some("EL_PARANAL"),
+        "CTAO South" => Some("CTAO_SOUTH"),
         "Roque de los Muchachos Observatory" => Some("ROQUE_DE_LOS_MUCHACHOS"),
+        "CTAO North" => Some("CTAO_NORTH"),
         "Mauna Kea Observatory" => Some("MAUNA_KEA"),
         "La Silla Observatory" => Some("LA_SILLA_OBSERVATORY"),
         _ => None,
@@ -79,7 +81,9 @@ fn main() {
 
     for required in [
         "EL_PARANAL",
+        "CTAO_SOUTH",
         "ROQUE_DE_LOS_MUCHACHOS",
+        "CTAO_NORTH",
         "MAUNA_KEA",
         "LA_SILLA_OBSERVATORY",
     ] {

--- a/data/observatories.toml
+++ b/data/observatories.toml
@@ -15,6 +15,20 @@ height_m = 2635.0
 reference_pressure_hpa = 744.0
 
 [[observatory]]
+# Array coordinates: CTAO-South site documentation; DMS converted to decimal degrees.
+# CTA site references use a nominal 2150 m above-sea-level altitude. Because no
+# WGS84 ellipsoidal datum is stated, treat 2150 m as orthometric height H and
+# convert with the EGM96 15' geoid undulation N = +34.6407 m at this position:
+# h(WGS84) = H + N = 2184.6407 m, rounded to 2184.6 m.
+# Pressure: ISA troposphere estimate at H = 2150 m,
+# 1013.25 * (1 - 2.25577e-5 * H)^5.25588 = 780.26 hPa, rounded to 780 hPa.
+name = "CTAO South"
+longitude_deg = -70.31634444444444
+latitude_deg = -24.683427777777776
+height_m = 2184.6
+reference_pressure_hpa = 780.0
+
+[[observatory]]
 # Coordinates/height: Instituto de Astrofísica de Canarias site documentation.
 # Pressure: established Siderust/NSB reference value for La Palma.
 name = "Roque de los Muchachos Observatory"
@@ -22,6 +36,20 @@ longitude_deg = -17.8925
 latitude_deg = 28.7543
 height_m = 2396.0
 reference_pressure_hpa = 744.0
+
+[[observatory]]
+# Array coordinates and nominal 2200 m above-sea-level altitude: CTAO-North
+# site documentation; DMS converted to decimal degrees. Because no WGS84
+# ellipsoidal datum is stated, treat 2200 m as orthometric height H and convert
+# with the EGM96 15' geoid undulation N = +40.2246 m at this position:
+# h(WGS84) = H + N = 2240.2246 m, rounded to 2240.2 m.
+# Pressure: ISA troposphere estimate at H = 2200 m,
+# 1013.25 * (1 - 2.25577e-5 * H)^5.25588 = 775.41 hPa, rounded to 775 hPa.
+name = "CTAO North"
+longitude_deg = -17.892005
+latitude_deg = 28.762164
+height_m = 2240.2
+reference_pressure_hpa = 775.0
 
 [[observatory]]
 # Coordinates/height: established Siderust Mauna Kea reference position.

--- a/tests/test_ctao_observatories.rs
+++ b/tests/test_ctao_observatories.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+use siderust::catalogs::observatories::{
+    ObservatoryCatalog, CTAO_NORTH, CTAO_SOUTH, EL_PARANAL, ROQUE_DE_LOS_MUCHACHOS,
+};
+
+#[test]
+fn ctao_generated_constants_match_builtin_catalog() {
+    let catalog = ObservatoryCatalog::builtin();
+
+    assert_eq!(catalog.get("CTAO North"), Some(&CTAO_NORTH));
+    assert_eq!(catalog.get("CTAO South"), Some(&CTAO_SOUTH));
+}
+
+#[test]
+fn ctao_records_match_authoritative_array_coordinates() {
+    assert_eq!(CTAO_NORTH.geodetic.lon.value(), -17.892005);
+    assert_eq!(CTAO_NORTH.geodetic.lat.value(), 28.762164);
+    assert_eq!(CTAO_NORTH.geodetic.height.value(), 2240.2);
+    assert_eq!(CTAO_NORTH.reference_pressure.value(), 775.0);
+
+    assert_eq!(CTAO_SOUTH.geodetic.lon.value(), -70.31634444444444);
+    assert_eq!(CTAO_SOUTH.geodetic.lat.value(), -24.683427777777776);
+    assert_eq!(CTAO_SOUTH.geodetic.height.value(), 2184.6);
+    assert_eq!(CTAO_SOUTH.reference_pressure.value(), 780.0);
+}
+
+#[test]
+fn ctao_sites_remain_distinct_from_nearby_observatories() {
+    assert_ne!(CTAO_NORTH.geodetic, ROQUE_DE_LOS_MUCHACHOS.geodetic);
+    assert_ne!(CTAO_SOUTH.geodetic, EL_PARANAL.geodetic);
+}


### PR DESCRIPTION
## Summary

- add distinct `CTAO North` and `CTAO South` records to the canonical `data/observatories.toml` catalog
- generate public `CTAO_NORTH` and `CTAO_SOUTH` constants from the same TOML source
- add integration coverage proving the generated constants are present in `ObservatoryCatalog::builtin()`, match the authoritative array coordinates, and remain distinct from Roque de los Muchachos / El Paranal

## Site data and derivation

Array coordinates use the CTAO-published positions:

- CTAO North: 28º 45′ 43.7904″ N, 17º 53′ 31.218″ W → `28.762164`, `-17.892005`
- CTAO South: 24º 41′ 0.34″ S, 70º 18′ 58.84″ W → `-24.683427777777776`, `-70.31634444444444`

The catalog requires WGS84 ellipsoidal height rather than an unspecified above-sea-level altitude. The TOML comments therefore make the conversion explicit instead of reusing nearby ORM/Paranal values:

- CTAO North: nominal `H = 2200 m`; EGM96 15′ geoid undulation `N = +40.2246 m`; `h = H + N = 2240.2246 m`, stored as `2240.2 m`
- CTAO South: nominal `H = 2150 m`; EGM96 15′ geoid undulation `N = +34.6407 m`; `h = H + N = 2184.6407 m`, stored as `2184.6 m`

Reference pressures are independent ISA troposphere estimates at the published site altitudes, using

`p = 1013.25 * (1 - 2.25577e-5 * H)^5.25588`

which gives `775.41 hPa` for CTAO North and `780.26 hPa` for CTAO South, rounded to `775 hPa` and `780 hPa` respectively.

No NSB-specific site-profile assumptions are introduced.

Closes #93